### PR TITLE
fix: correctly log `makeappx.exe` errors

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -28,12 +28,24 @@ const  run = async (executable: string, args: Array<string>)  => {
     });
 
     proc.on('exit', (code: number) => {
-      log.debug(`Output from ${executable}:`, cleanOutData(stdout));
-      if (code !== 0) {
-        log.error(`Output from ${executable}:`, false, cleanOutData(stdout))
-        return reject(new Error(`Failed running ${executable} Exit Code: ${code} See previous errors for details`))
+      if (code === 0) {
+        log.debug(`stdout of ${executable}`, cleanOutData(stdout));
+        return resolve(stdout);
+      } else {
+        if (stderr !== '') {
+          log.error(`stderr of ${executable}`, false, cleanOutData(stderr));
+        }
+
+        if (stdout !== '') {
+          log.error(`stdout of ${executable}`, false, cleanOutData(stdout));
+        }
+        return reject(
+          new Error(
+            `Failed running ${executable} Exit Code: ${code} See previous errors for details`
+          )
+        );
+
       }
-      return resolve(stdout);
     });
 
     proc.stdin.end();


### PR DESCRIPTION
From the erroring e2e tests in #17, you can observe that the stderr output from MakeAppx.exe is empty:

```
error: stderr of C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\makeappx.exe
  [
    ""
  ]
```

https://github.com/electron-userland/electron-windows-msix/actions/runs/19087183080/job/54529945541?pr=17

Testing locally, it seems like the error output comes from stdout anyways. This PR fixes the issue and correctly logs error output.