### PR TITLE
Don't create dev certificate when using Azure trusted signing

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -229,7 +229,7 @@ export const makeProgramOptions = async (options: PackagingOptions, manifestVars
   let cert_cer = '';
   let cert_pass = '';
 
-  const createDevCert = sign && !options.windowsSignOptions?.certificateFile && !process.env.WINDOWS_CERTIFICATE_FILE;
+  const createDevCert = sign && !options.windowsSignOptions?.certificateFile && !process.env.WINDOWS_CERTIFICATE_FILE && !options.windowsSignOptions.signWithParams?.includes('/dlib');
   if(sign) {
     windowsSignOptions = options.windowsSignOptions || {files: [msix], certificateFile: '', certificatePassword: '', hashes: ["sha256"] as any };
     cert_pass = windowsSignOptions?.certificatePassword || process.env.WINDOWS_CERTIFICATE_PASSWORD || generatePassword();


### PR DESCRIPTION
[Azure artifact signing](https://www.electronforge.io/guides/code-signing/code-signing-windows#using-azure-trusted-signing) uses a dll and json config file to retrieve the certificates required to sign artifacts with `signtool.exe`.
The configuration is passed to `signtool.exe` using the `/dlib` and `/dmdf` flags.
No certificate is explicitly passed using the `/f` flag.
The MSIX packager however automatically generates a dev certificate if none is provided and adds it to the arguments for `signtool.exe`, effectively blocking artifact signing.

This PR changes the dev cert creation behavior by simply not creating one if the parameters for `signtool.exe` contains the `/dlib` flag

Fixes https://github.com/electron-userland/electron-windows-msix/issues/24