### PR TITLE
fix: don't create dev cert if certificate is not explicitly specified

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -237,7 +237,7 @@ export const makeProgramOptions = async (options: PackagingOptions, manifestVars
   let cert_cer = '';
   let cert_pass = '';
 
-  const createDevCert = sign && !options.windowsSignOptions?.certificateFile && !process.env.WINDOWS_CERTIFICATE_FILE;
+  const createDevCert = sign && !options.windowsSignOptions && !process.env.WINDOWS_CERTIFICATE_FILE;
   if(sign) {
     windowsSignOptions = options.windowsSignOptions || {files: [msix], certificateFile: '', certificatePassword: '', hashes: ["sha256"] as any };
     cert_pass = windowsSignOptions?.certificatePassword || process.env.WINDOWS_CERTIFICATE_PASSWORD || generatePassword();

--- a/test/e2e/signing.spec.ts
+++ b/test/e2e/signing.spec.ts
@@ -115,6 +115,20 @@ describe('signing', () => {
       const certStatus = await getCertStatus(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'));
       expect(certStatus).toBe('Valid');
     });
+
+    it('should sign the app when windowsSignOptions is set without certificateFile and both cert and password are from env vars', async () => {
+      process.env.WINDOWS_CERTIFICATE_FILE = path.join(__dirname, 'fixtures', 'MSIXDevCert.pfx');
+      process.env.WINDOWS_CERTIFICATE_PASSWORD = 'Password123';
+      await packageMSIX({
+        appDir: path.join(__dirname, 'fixtures', 'app-x64'),
+        outputDir: path.join(__dirname, '..', '..', 'out'),
+        appManifest: path.join(__dirname, 'fixtures', 'AppxManifest_x64.xml'),
+        windowsSignOptions: {} as any,
+      });
+      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(true);
+      const certStatus = await getCertStatus(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'));
+      expect(certStatus).toBe('Valid');
+    });
   });
 
   describe('signing with a generated dev cert', () => {

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -1247,7 +1247,7 @@ describe('utils', () => {
       });
     });
 
-    it('should create a dev cert with the provided sign password', async () => {
+    it('should not create a dev cert when windowsSignOptions is provided without certificateFile', async () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
         windowsSignOptions: {
@@ -1264,14 +1264,15 @@ describe('utils', () => {
       expect(programOptions).toStrictEqual({
         ...defaultExpectedProgramOptions,
         windowsSignOptions: {
-          ...defaultExpectedWindowsSignOptions,
           certificatePassword: 'password',
+          files: ["C:\\out\\app_x64.msix"],
+          hashes: ['sha256'] as any,
         },
         publisher: 'Electron',
-        cert_pfx: 'C:\\out\\dev_cert.pfx',
-        cert_cer: 'C:\\out\\dev_cert.cer',
+        cert_pfx: '',
+        cert_cer: '',
         cert_pass: 'password',
-        createDevCert: true,
+        createDevCert: false,
       });
     });
 
@@ -1309,6 +1310,28 @@ describe('utils', () => {
         msix: 'C:\\out\\app.msix',
         publisher: '',
       });
+    });
+
+    it('should not create a dev cert when WINDOWS_CERTIFICATE_FILE env var is set', async () => {
+      process.env.WINDOWS_CERTIFICATE_FILE = 'C:\\cert.pfx';
+      try {
+        vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
+        const programOptions = await makeProgramOptions(minimalPackagingOptions);
+        expect(programOptions).toStrictEqual({
+          ...defaultExpectedProgramOptions,
+          windowsSignOptions: {
+            files: ["C:\\out\\app_x64.msix"],
+            certificateFile: '',
+            certificatePassword: expect.any(String),
+            hashes: ['sha256'] as any,
+          },
+          cert_pfx: '',
+          cert_cer: '',
+          createDevCert: false,
+        });
+      } finally {
+        delete process.env.WINDOWS_CERTIFICATE_FILE;
+      }
     });
 
     it('should not sign the package if sign is false', async () => {

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -1133,11 +1133,12 @@ describe('utils', () => {
       expect(programOptions).toStrictEqual({
         ...defaultExpectedProgramOptions,
         windowsSignOptions: {
-          certificateFile: "C:\\out\\dev_cert.pfx",
-          certificatePassword: expect.any(String),
           hashes: ['sha256'] as any,
           appDirectory: 'C:\\app',
         },
+        cert_pfx: '',
+        cert_cer: '',
+        createDevCert: false,
         msix: 'C:\\out\\MySuperApp_arm64.msix'
       });
     });
@@ -1177,9 +1178,13 @@ describe('utils', () => {
       expect(programOptions).toStrictEqual({
         ...defaultExpectedProgramOptions,
         windowsSignOptions: {
-          ...defaultExpectedWindowsSignOptions,
+          files: ["C:\\out\\app_x64.msix"],
+          hashes: ['sha256'] as any,
           signWithParams: ['1', '2', '3'],
         },
+        cert_pfx: '',
+        cert_cer: '',
+        createDevCert: false,
         sign: true });
     });
 


### PR DESCRIPTION
Hey, thanks for the work you're doing.

In my project, we use the https://github.com/electron/windows-sign `automaticallySelectCertificate` option and leave the administration of the certificate to the owner of the ci runner.

Unfortunately, unless I missed something, in `msix` maker, if I don't explicitly specify a certificate file, it triggers the creation of a dev certificate which kind of makes sense but blocks me.

I would like to suggest to add a way with configuration to be able to not have a `certificateFile` while not using the dev cert.

This PR suggest a simple way, instead of activating the dev cert only with `certificateFile` prop being set, deactivate dev cert if any `windowsSignOptions` are set. At least it works for me (I plugged my fork for now). What do you think?