### PR TITLE
Add `compress` option to control MSIX compression

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -89,7 +89,7 @@ export const pri = async (program: ProgramOptions) => {
 }
 
 export const make = async (program: ProgramOptions) => {
-  const { makeMsix, layoutDir, msix, isSparsePackage} = program;
+  const { makeMsix, layoutDir, msix, isSparsePackage, compress } = program;
   const args = [
     'pack',
     '/d',
@@ -101,6 +101,9 @@ export const make = async (program: ProgramOptions) => {
 
   if(isSparsePackage) {
     args.push('/nv');
+  }
+  if(!compress) {
+    args.push('/nc');
   }
   await run(makeMsix, args);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,8 @@ export interface PackagingOptions {
   windowsKitPath ? : string;
   /** Indicates whether to create Pri resource files. It will be enabled by default. */
   createPri ? : boolean;
+  /** Indicates whether to compress package files. It will be enabled by default. */
+  compress ? : boolean;
   /**
    * Indicates whether to sign the MSIX package. It will be enabled by default. If cert or signParams are not provided then the package will be signed with a dev cert.
    * If sign is false then the package will not be signed.
@@ -170,6 +172,7 @@ export interface ProgramOptions {
   priConfig: string;
   priFile: string;
   isSparsePackage: boolean;
+  compress: boolean;
   sign: boolean;
   windowsSignOptions: WindowsSignOptions;
   createDevCert: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -230,6 +230,7 @@ export const makeProgramOptions = async (options: PackagingOptions, manifestVars
   const priConfig = path.join(layoutDir, 'priconfig.xml');
   const priFile =  path.join(layoutDir, 'resources.pri');
   const createPri = options.createPri !== undefined ? options.createPri : true;
+  const compress = options.compress !== undefined ? options.compress : true;
   const publisher = options.manifestVariables?.publisher || manifestPublisher || '';
   const sign = options.sign !== undefined ? options.sign : true;
   let windowsSignOptions: WindowsSignOptions
@@ -284,6 +285,7 @@ export const makeProgramOptions = async (options: PackagingOptions, manifestVars
     priFile,
     createPri,
     isSparsePackage,
+    compress,
     sign,
     windowsSignOptions,
     createDevCert,

--- a/test/e2e/packaging.spec.ts
+++ b/test/e2e/packaging.spec.ts
@@ -326,4 +326,15 @@ describe('packaging', () => {
     }
     expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(false);
   });
+
+  it('should package without compression', async () => {
+     await packageMSIX({
+      appDir: path.join(__dirname, 'fixtures', 'app-x64'),
+      outputDir: path.join(__dirname, '..', '..', 'out'),
+      appManifest: path.join(__dirname, 'fixtures', 'AppxManifest_x64.xml'),
+      windowsKitVersion: '10.0.26100.0',
+      compress: false,
+    });
+    expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(true);
+  });
 });

--- a/test/unit/bin.spec.ts
+++ b/test/unit/bin.spec.ts
@@ -175,6 +175,7 @@ describe('bin', () => {
       layoutDir: 'C:\\layoutDir',
       msix: 'C:\\msix',
       isSparsePackage: false,
+      compress: true,
     } as any);
     expect(spawn).toHaveBeenCalledWith('C:\\makeappx.exe', ['pack', '/d', 'C:\\layoutDir', '/p', 'C:\\msix', '/o'], {});
   });
@@ -185,8 +186,20 @@ describe('bin', () => {
       layoutDir: 'C:\\layoutDir',
       msix: 'C:\\msix',
       isSparsePackage: true,
+      compress: true,
     } as any);
     expect(spawn).toHaveBeenCalledWith('C:\\makeappx.exe', ['pack', '/d', 'C:\\layoutDir', '/p', 'C:\\msix', '/o', '/nv'], {});
+  });
+
+  it('should call make with the correct arguments for an uncompressed package', async () => {
+    await make({
+      makeMsix: 'C:\\makeappx.exe',
+      layoutDir: 'C:\\layoutDir',
+      msix: 'C:\\msix',
+      isSparsePackage: false,
+      compress: false,
+    } as any);
+    expect(spawn).toHaveBeenCalledWith('C:\\makeappx.exe', ['pack', '/d', 'C:\\layoutDir', '/p', 'C:\\msix', '/o', '/nc'], {});
   });
 
   it('should call sign with the correct arguments', async () => {

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -1027,6 +1027,7 @@ describe('utils', () => {
       cert_pass: expect.any(String),
       createPri: true,
       isSparsePackage: false,
+      compress: true,
       sign: true,
     } as any;
 
@@ -1158,6 +1159,24 @@ describe('utils', () => {
         ...defaultExpectedProgramOptions,
         windowsSignOptions: defaultExpectedWindowsSignOptions,
         createPri: false });
+    });
+
+    it('should disable compression if compress is false', async () => {
+      const packagingOptions: PackagingOptions = {
+        ...minimalPackagingOptions,
+        manifestVariables: {
+          targetArch: 'x64',
+          publisher: 'Electron',
+          packageVersion: '1.2.3',
+        } as any,
+        compress: false,
+      }
+      vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
+      const programOptions = await makeProgramOptions(packagingOptions);
+      expect(programOptions).toStrictEqual({
+        ...defaultExpectedProgramOptions,
+        windowsSignOptions: defaultExpectedWindowsSignOptions,
+        compress: false });
     });
 
     it('should use the sign params if provided', async () => {


### PR DESCRIPTION
This allows creating uncompressed MSIX packages. We're distributing MSIX package updates using a generic, differential update mechanism that relies on content-aware chunking which compression reduces the effectiveness of.