### PR TITLE
feat: COM + toast notification activation in generated AppxManifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ appDisplayName            - The name of the MSIX package. This will be used to s
 targetArch                - The target architecture of the MSIX package. This will be used to set the ProcessorArchitecture attribute in the AppxManifest.xml. 'x64' |'arm64' | 'x86' | 'arm' | '*';
 packageMinOSVersion       - The minimum OS version the MSIX package requires. This will be used to set the MinVersion attribute in the TargetDeviceFamily element in theAppxManifest.xml.
 packageMaxOSVersionTested - The maximum OS version the MSIX package has been tested on. This will be used to set the MaxVersionTested attribute in the TargetDeviceFamily element in the AppxManifest.xml.
+comToastActivation        - Optional. Adds COM server (`windows.comServer`) and toast activation (`windows.toastNotificationActivation`) extensions so the packaged app can handle toast activations. Object with `toastActivatorClsid` (GUID, same for COM class and ToastActivatorCLSID). Optional: `arguments` (default -ToastActivated), `executable` (exe file name, default from appExecutable). Ignored when using `appManifest`.
 ```
 
 ### Minimal example that creates a manifest and a dev cert
@@ -66,6 +67,27 @@ await packageMSIX({
     packageVersion: '1.42.0.0',
     appExecutable: 'hellomsix.exe',
     targetArch: 'x64',
+  },
+});
+```
+
+### Toast / COM activation (generated manifest only)
+
+Register the same CLSID for a COM out-of-process server and for toast notification activation (see [Microsoft: Toast activations from desktop apps](https://learn.microsoft.com/en-us/windows/apps/develop/notifications/app-notifications/toast-desktop-apps)). You can pass the GUID with or without `{}`; the generated manifest writes it **without** braces, as MakeAppx expects.
+
+```ts
+await packageMSIX({
+  appDir: 'C:\\temp\\myapp',
+  outputDir: 'C:\\temp\\out',
+  manifestVariables: {
+    publisher: 'CN=Dev Publisher',
+    packageIdentity: 'com.example.app',
+    packageVersion: '1.0.0.0',
+    appExecutable: 'myapp.exe',
+    targetArch: 'x64',
+    comToastActivation: {
+      toastActivatorClsid: '{12345678-1234-4123-a123-123456789abc}',
+    },
   },
 });
 ```

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ await packageMSIX({
 Register the same CLSID for a COM out-of-process server and for toast notification activation (see [Microsoft: Toast activations from desktop apps](https://learn.microsoft.com/en-us/windows/apps/develop/notifications/app-notifications/toast-desktop-apps)). You can pass the GUID with or without `{}`; the generated manifest writes it **without** braces, as MakeAppx expects.
 
 ```ts
+import { packageMSIX } from "electron-windows-msix";
+
 await packageMSIX({
   appDir: 'C:\\temp\\myapp',
   outputDir: 'C:\\temp\\out',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import { make, pri, priConfig, sign } from './bin';
 import { ensureDevCert } from './cert';
 import { getManifestVariables } from './manifestation';
-import { type Artifacts, type ManifestGenerationVariables, type PackagingOptions, type WindowsSignOptions } from './types';
+import { type Artifacts, type ComToastActivationOptions, type ManifestGenerationVariables, type PackagingOptions, type WindowsSignOptions } from './types';
 import { createLayout, ensureFolders, makeProgramOptions, setLogLevel, verifyOptions } from './utils';
 
-export type { PackagingOptions, ManifestGenerationVariables, Artifacts, WindowsSignOptions };
+export type { PackagingOptions, ManifestGenerationVariables, ComToastActivationOptions, Artifacts, WindowsSignOptions };
 
 export const packageMSIX = async (options: PackagingOptions) => {
   setLogLevel(options);

--- a/src/manifestation.ts
+++ b/src/manifestation.ts
@@ -17,7 +17,8 @@ function escapeXmlAttr(value: string): string {
     .replace(/&/g, '&amp;')
     .replace(/"/g, '&quot;')
     .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+    .replace(/>/g, '&gt;')
+    .replace(/'/g, '&apos;');
 }
 
 /**
@@ -46,7 +47,7 @@ export function buildComToastActivationXml(
 ): { comXmlns: string; ignorableCom: string; applicationExtensions: string } {
   const clsid = normalizeToastActivatorClsid(opts.toastActivatorClsid, false);
   const exeName = path.basename(opts.executable?.trim() || appExecutableFileName);
-  const exePath = `app\\${exeName}`;
+  const exePath = `app\\${escapeXmlAttr(exeName)}`;
   const args = escapeXmlAttr(opts.arguments ?? '-ToastActivated');
 
   const extensions = getComToastExtensionsTemplate();

--- a/src/manifestation.ts
+++ b/src/manifestation.ts
@@ -1,16 +1,69 @@
 import * as path from "path";
 import fs from "fs-extra";
 
-import { ManifestVariables, PackagingOptions } from "./types";
+import { ComToastActivationOptions, ManifestVariables, PackagingOptions } from "./types";
 import { removeFileExtension, removePublisherPrefix } from "./utils";
 import { ensureWindowsVersion } from "./win-version";
 
 
-const DEFAULT_OS_VERSION = '10.0.14393.0';
+const DEFAULT_OS_VERSION = '10.0.19041.0';
 const DEFAULT_BACKGROUND_COLOR = 'transparent';
 
+const TEMPLATES_DIR = path.join(__dirname, '../static/templates');
+const COM_MANIFEST_NS = 'http://schemas.microsoft.com/appx/manifest/com/windows10';
+
+function escapeXmlAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Normalize toast activator CLSID: trim, strip optional braces, lowercase hex.
+ * @param braced - If `true` (default), `{guid}`; if `false`, `guid` for Appx manifest attributes (no braces).
+ */
+export function normalizeToastActivatorClsid(raw: string, braced = true): string {
+  const inner = raw.trim().replace(/^\{/, '').replace(/\}$/, '').toLowerCase();
+  return braced ? `{${inner}}` : inner;
+}
+
+let comToastExtensionsTemplateCache: string | null = null;
+
+function getComToastExtensionsTemplate(): string {
+  if (comToastExtensionsTemplateCache === null) {
+    comToastExtensionsTemplateCache = fs
+      .readFileSync(path.join(TEMPLATES_DIR, 'ComToastActivation.xml.in'), 'utf-8')
+      .trimEnd();
+  }
+  return comToastExtensionsTemplateCache;
+}
+
+export function buildComToastActivationXml(
+  opts: ComToastActivationOptions,
+  appExecutableFileName: string
+): { comXmlns: string; ignorableCom: string; applicationExtensions: string } {
+  const clsid = normalizeToastActivatorClsid(opts.toastActivatorClsid, false);
+  const exeName = path.basename(opts.executable?.trim() || appExecutableFileName);
+  const exePath = `app\\${exeName}`;
+  const args = escapeXmlAttr(opts.arguments ?? '-ToastActivated');
+
+  const extensions = getComToastExtensionsTemplate();
+  const applicationExtensions = extensions
+    .replace(/\{\{ExeServerExecutable\}\}/g, exePath)
+    .replace(/\{\{ExeServerArguments\}\}/g, args)
+    .replace(/\{\{ToastActivatorClsid\}\}/g, clsid);
+
+  return {
+    comXmlns: `xmlns:com="${COM_MANIFEST_NS}"`,
+    ignorableCom: ' com',
+    applicationExtensions,
+  };
+}
+
 const getTemplate = () => {
-  const content = fs.readFileSync(path.join(__dirname, `../static/templates/AppxManifest.xml.in`), 'utf-8');
+  const content = fs.readFileSync(path.join(TEMPLATES_DIR, 'AppxManifest.xml.in'), 'utf-8');
   return content;
 };
 
@@ -94,11 +147,21 @@ export const manifest = async (options: PackagingOptions) => {
     appExecutable,
     targetArch,
     packageDescription,
-    packageBackgroundColor
+    packageBackgroundColor,
+    comToastActivation,
   } = options.manifestVariables;
   const appName = removeFileExtension(appExecutable);
   const publisherName = removePublisherPrefix(publisher);
   const version = ensureWindowsVersion(packageVersion);
+  let comXmlns = '';
+  let ignorableNamespacesCom = '';
+  let applicationExtensions = '';
+  if (comToastActivation?.toastActivatorClsid) {
+    const built = buildComToastActivationXml(comToastActivation, appExecutable);
+    comXmlns = built.comXmlns;
+    ignorableNamespacesCom = built.ignorableCom;
+    applicationExtensions = built.applicationExtensions;
+  }
   const manifest = template
     .replace(/{{IdentityName}}/g, packageIdentity)
     .replace(/{{AppDisplayName}}/g, appDisplayName || packageDisplayName || appName)
@@ -111,7 +174,10 @@ export const manifest = async (options: PackagingOptions) => {
     .replace(/{{PackageDescription}}/g, packageDescription || packageDisplayName || appDisplayName || appName)
     .replace(/{{PackageBackgroundColor}}/g, packageBackgroundColor || DEFAULT_BACKGROUND_COLOR)
     .replace(/{{AppExecutable}}/g, appExecutable)
-    .replace(/{{ProcessorArchitecture}}/g, targetArch);
+    .replace(/{{ProcessorArchitecture}}/g, targetArch)
+    .replace(/{{ComXmlns}}/g, comXmlns)
+    .replace(/{{IgnorableNamespacesCom}}/g, ignorableNamespacesCom)
+    .replace(/{{ApplicationExtensions}}/g, applicationExtensions);
 
   return manifest;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,29 @@ export interface ManifestGenerationVariables {
     * If a manifest is provided then this will be ignored.
     */
   packageMaxOSVersionTested ? : string;
+  /**
+   * When set, the generated manifest includes COM server registration and
+   * `windows.toastNotificationActivation` so packaged desktop apps can handle
+   * toast activations via the same CLSID.
+   * Ignored when using a pre-built `appManifest` file.
+   */
+  comToastActivation ? : ComToastActivationOptions;
+}
+
+/** Options for COM server + toast notification activation in AppxManifest. */
+export interface ComToastActivationOptions {
+  /**
+   * CLSID for the toast activator (same value as `ToastActivatorCLSID` and `com:Class Id`).
+   * With or without braces in options; the manifest omits braces (MakeAppx requirement).
+   */
+  toastActivatorClsid: string;
+  /** `Arguments` on `com:ExeServer`. Default `-ToastActivated`. */
+  arguments ? : string;
+  /**
+   * Executable file name only (e.g. `MyApp.exe`). Defaults to `appExecutable` basename.
+   * The manifest uses `app\\{executable}` to match the layout.
+   */
+  executable ? : string;
 }
 
 export interface PackagingOptions {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,12 +80,20 @@ export const verifyOptions = async (options: PackagingOptions, manifestVars?: Ma
     if(!options.manifestVariables.packageDisplayName) log.warn('Neither package display name <packageDisplayName> nor app manifest <appManifest> provided. Using app executable as display name.');
     if(!options.manifestVariables.appExecutable) log.error('Neither app executable <appExecutable> nor app manifest <appManifest> provided.', true);
     if(!options.manifestVariables.targetArch) log.error('Neither target architecture <targetArch> nor app manifest <appManifest> provided.', true);
-    if(!options.manifestVariables.packageMinOSVersion) log.warn('Neither package min OS version <packageMinOSVersion> nor app manifest <appManifest> provided. Using default OS version 10.0.14393.0.');
-    if(!options.manifestVariables.packageMaxOSVersionTested) log.warn('Neither package max OS version tested <packageMaxOSVersionTested> nor app manifest <appManifest> provided. Using default OS version 10.0.14393.0.');
+    if(!options.manifestVariables.packageMinOSVersion) log.warn('Neither package min OS version <packageMinOSVersion> nor app manifest <appManifest> provided. Using default OS version 10.0.19041.0.');
+    if(!options.manifestVariables.packageMaxOSVersionTested) log.warn('Neither package max OS version tested <packageMaxOSVersionTested> nor app manifest <appManifest> provided. Using default OS version 10.0.19041.0.');
     if(!options.manifestVariables.packageIdentity) log.error('Neither package identity <packageIdentity> nor app manifest <appManifest> provided.', true);
     if(!options.manifestVariables.appDisplayName) log.warn('Neither app display name <appDisplayName> nor app manifest <appManifest> provided. Using app executable as display name.');
     if(!options.manifestVariables.packageDescription) log.warn('Neither package description <packageDescription> nor app manifest <appManifest> provided. Using app executable as description.');
     if(!options.manifestVariables.packageBackgroundColor) log.warn('Neither package background color <packageBackgroundColor> nor app manifest <appManifest> provided. Using default background color transparent.');
+    const cta = options.manifestVariables.comToastActivation;
+    if (cta?.toastActivatorClsid) {
+      const guid = cta.toastActivatorClsid.trim().replace(/^\{|\}$/g, '');
+      const guidOk = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(guid);
+      if (!guidOk) {
+        log.error('comToastActivation.toastActivatorClsid must be a valid GUID.', true, { toastActivatorClsid: cta.toastActivatorClsid });
+      }
+    }
     hasManifestParams = true;
   }
   if(!hasManifestParams && !options.appManifest) log.error('Neither app manifest <appManifest> nor manifest variables <manifestVariables> provided.', true);

--- a/static/templates/AppxManifest.xml.in
+++ b/static/templates/AppxManifest.xml.in
@@ -6,7 +6,8 @@
   xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
   xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
   xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2"
-  IgnorableNamespaces="uap uap3 desktop2">
+  {{ComXmlns}}
+  IgnorableNamespaces="uap uap3 desktop2{{IgnorableNamespacesCom}}">
   <Identity Name="{{IdentityName}}"
           ProcessorArchitecture="{{ProcessorArchitecture}}"
           Version="{{Version}}"
@@ -35,6 +36,7 @@
           Square150x150Logo="assets\Square150x150Logo.png"
           BackgroundColor="{{PackageBackgroundColor}}">
       </uap:VisualElements>
+{{ApplicationExtensions}}
     </Application>
   </Applications>
 </Package>

--- a/static/templates/ComToastActivation.xml.in
+++ b/static/templates/ComToastActivation.xml.in
@@ -1,0 +1,12 @@
+          <Extensions>
+            <com:Extension Category="windows.comServer">
+              <com:ComServer>
+                <com:ExeServer Executable="{{ExeServerExecutable}}" Arguments="{{ExeServerArguments}}">
+                  <com:Class Id="{{ToastActivatorClsid}}"/>
+                </com:ExeServer>
+              </com:ComServer>
+            </com:Extension>
+            <desktop:Extension Category="windows.toastNotificationActivation">
+              <desktop:ToastNotificationActivation ToastActivatorCLSID="{{ToastActivatorClsid}}" />
+            </desktop:Extension>
+          </Extensions>

--- a/test/e2e/packaging.spec.ts
+++ b/test/e2e/packaging.spec.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 
 import { packageMSIX } from "../../src/index";
 import { installDevCert } from './utils/cert';
+import { readAppxManifestFromMsix } from './utils/installer';
 
 describe('packaging', () => {
   beforeAll(async () => {
@@ -41,6 +42,46 @@ describe('packaging', () => {
       windowsKitVersion: '10.0.26100.0',
     });
     expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(true);
+  });
+
+  it('should package with comToastActivation and embed COM + toast extensions in AppxManifest', async () => {
+    const toastClsid = 'A0E0E0E0-E0E0-4AE0-A0E0-E0E0E0E0E0E0';
+    await packageMSIX({
+      appDir: path.join(__dirname, 'fixtures', 'app-x64'),
+      outputDir: path.join(__dirname, '..', '..', 'out'),
+      manifestVariables: {
+        appDisplayName: 'Hello MSIX',
+        publisher: 'CN=Dev Publisher',
+        publisherDisplayName: 'Dev Publisher',
+        packageDisplayName: 'Hello MSIX',
+        packageDescription: 'Just a test app',
+        packageBackgroundColor: '#000000',
+        packageIdentity: 'com.example.app',
+        packageVersion: '1.42.0.0',
+        appExecutable: 'hellomsix.exe',
+        targetArch: 'x64',
+        packageMinOSVersion: '10.0.19041.0',
+        packageMaxOSVersionTested: '10.0.19041.0',
+        comToastActivation: {
+          toastActivatorClsid: toastClsid,
+        },
+      },
+      windowsKitVersion: '10.0.26100.0',
+      sign: false,
+    });
+    const msixPath = path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix');
+    expect(fs.existsSync(msixPath)).toBe(true);
+    const manifestXml = await readAppxManifestFromMsix(msixPath);
+    expect(manifestXml).toContain('xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"');
+    expect(manifestXml).toMatch(/IgnorableNamespaces="[^"]*\bcom\b/);
+    expect(manifestXml).toContain('Category="windows.comServer"');
+    expect(manifestXml).toContain('Category="windows.toastNotificationActivation"');
+    expect(manifestXml).toContain(
+      'ToastActivatorCLSID="a0e0e0e0-e0e0-4ae0-a0e0-e0e0e0e0e0e0"'
+    );
+    expect(manifestXml).toMatch(
+      /<com:ExeServer[^>]*Executable="app\\hellomsix\.exe"[^>]*Arguments="-ToastActivated"/
+    );
   });
 
   it('should package the app with prerelease version manifest variables', async () => {

--- a/test/e2e/utils/installer.ts
+++ b/test/e2e/utils/installer.ts
@@ -16,4 +16,13 @@ export const checkInstall = async (name: string, version?: string) => {
     name: fields[0],
     version: fields[1],
   }
+};
+
+export async function readAppxManifestFromMsix(msixPath: string): Promise<string> {
+  const p = msixPath.replace(/'/g, "''");
+  return (
+    await powershell(
+      `Add-Type -AssemblyName System.IO.Compression.FileSystem; $z = [System.IO.Compression.ZipFile]::OpenRead('${p}'); try { $e = $z.GetEntry('AppxManifest.xml'); $r = New-Object System.IO.StreamReader($e.Open()); $r.ReadToEnd() } finally { $z.Dispose() }`
+    )
+  ).trim();
 }

--- a/test/unit/bin.spec.ts
+++ b/test/unit/bin.spec.ts
@@ -79,6 +79,43 @@ describe('bin', () => {
     expect(log.error).toHaveBeenCalledWith('stderr of certutil', false, ['certutil: Error: oops']);
   });
 
+  it('should log stdout when process exits with non-zero code and stdout is non-empty', async () => {
+    vi.mocked(spawn).mockImplementationOnce(() => {
+      const emitter = new EventEmitter() as any;
+      setImmediate(() => {
+        emitter.stdout.emit('data', Buffer.from('some stdout output\n'));
+        emitter.stderr.emit('data', Buffer.from('stderr message'));
+        emitter.emit('exit', 1, null);
+      });
+
+      emitter.stdout = new EventEmitter();
+      emitter.stderr = new EventEmitter();
+      emitter.stdin = { end: vi.fn() };
+      return emitter;
+    });
+    await expect(getCertPublisher('C:\\cert.pfx', 'password')).rejects.toThrow('Failed running certutil Exit Code: 1 See previous errors for details');
+    expect(log.error).toHaveBeenCalledWith('stdout of certutil', false, ['some stdout output', '']);
+  });
+
+  it('should not log stderr when process exits with non-zero code and stderr is empty', async () => {
+    vi.mocked(log.error).mockClear();
+    vi.mocked(spawn).mockImplementationOnce(() => {
+      const emitter = new EventEmitter() as any;
+      setImmediate(() => {
+        emitter.stdout.emit('data', Buffer.from('stdout only\n'));
+        emitter.emit('exit', 1, null);
+      });
+
+      emitter.stdout = new EventEmitter();
+      emitter.stderr = new EventEmitter();
+      emitter.stdin = { end: vi.fn() };
+      return emitter;
+    });
+    await expect(getCertPublisher('C:\\cert.pfx', 'password')).rejects.toThrow('Failed running certutil Exit Code: 1 See previous errors for details');
+    expect(log.error).not.toHaveBeenCalledWith('stderr of certutil', expect.anything(), expect.anything());
+    expect(log.error).toHaveBeenCalledWith('stdout of certutil', false, ['stdout only', '']);
+  });
+
   it('should log an error if no publisher is found in the cert', async () => {
     vi.mocked(spawn).mockImplementationOnce((_, __) => {
       const emitter = new EventEmitter() as any;

--- a/test/unit/manifestation.spec.ts
+++ b/test/unit/manifestation.spec.ts
@@ -3,7 +3,7 @@ import { expect, describe, it, vi } from 'vitest'
 
 import { makeProgramOptions } from '../../src/utils';
 import { ManifestGenerationVariables, PackagingOptions } from '../../src/types';
-import { getManifestVariables, manifest } from '../../src/manifestation';
+import { getManifestVariables, manifest, normalizeToastActivatorClsid } from '../../src/manifestation';
 
 vi.mock('fs-extra', async (importOriginal) => {
   const actual = await importOriginal() as Record < string,
@@ -111,7 +111,7 @@ describe('manifestation', () => {
       expect(appManifestIn).toMatch(/<DisplayName>HelloMSIX<\/DisplayName>/);
       expect(appManifestIn).toMatch(/<PublisherDisplayName>Jan Hannemann<\/PublisherDisplayName>/);
       expect(appManifestIn).toMatch(/<Logo>assets\\icon.png<\/Logo>/);
-      expect(appManifestIn).toMatch(/<TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.14393.0" MaxVersionTested="10.0.14393.0" \/>/);
+      expect(appManifestIn).toMatch(/<TargetDeviceFamily Name="Windows\.Desktop" MinVersion="[\d.]+" MaxVersionTested="[\d.]+" \/>/);
       expect(appManifestIn).toMatch(/<Application Id="App"  Executable="app\\HelloMSIX.exe" EntryPoint="Windows.FullTrustApplication">/);
       expect(appManifestIn).toMatch(/DisplayName="HelloMSIX"/);
       expect(appManifestIn).toMatch(/Description="HelloMSIX"/);
@@ -182,7 +182,6 @@ describe('manifestation', () => {
       expect(appManifestIn).toMatch(/Description="Custom App Display Name"/);
     });
 
-
     it('should return null if no manifest variables are provided', async () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
@@ -190,6 +189,79 @@ describe('manifestation', () => {
       }
       const appManifestIn = await manifest(packagingOptions);
       expect(appManifestIn).toBeNull();
+    });
+
+    it('should add COM server and toast activation extensions when comToastActivation is set', async () => {
+      const guid = 'A1B2C3D4-E5F6-7890-ABCD-EF1234567890';
+      const packagingOptions: PackagingOptions = {
+        ...minimalPackagingOptions,
+        manifestVariables: {
+          ...minimalManifestVariables,
+          comToastActivation: {
+            toastActivatorClsid: guid,
+            arguments: '-ToastActivated',
+          },
+        },
+      };
+      const appManifestIn = await manifest(packagingOptions);
+      expect(appManifestIn).toContain(
+        'xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"'
+      );
+      expect(appManifestIn).toMatch(/IgnorableNamespaces="[^"]*\bcom\b/);
+      expect(appManifestIn).toMatch(
+        /<com:Extension Category="windows\.comServer">[\s\S]*<com:ExeServer Executable="app\\HelloMSIX\.exe" Arguments="-ToastActivated">/
+      );
+      expect(appManifestIn).toContain(
+        '<com:Class Id="a1b2c3d4-e5f6-7890-abcd-ef1234567890"/>'
+      );
+      expect(appManifestIn).toContain(
+        '<desktop:ToastNotificationActivation ToastActivatorCLSID="a1b2c3d4-e5f6-7890-abcd-ef1234567890" />'
+      );
+    });
+
+    it('should use default arguments when omitted', async () => {
+      const packagingOptions: PackagingOptions = {
+        ...minimalPackagingOptions,
+        manifestVariables: {
+          ...minimalManifestVariables,
+          comToastActivation: {
+            toastActivatorClsid: 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB',
+          },
+        },
+      };
+      const appManifestIn = await manifest(packagingOptions);
+      expect(appManifestIn).toMatch(
+        /<com:ExeServer Executable="app\\HelloMSIX\.exe" Arguments="-ToastActivated">/
+      );
+      expect(appManifestIn).toContain(
+        '<com:Class Id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"/>'
+      );
+    });
+
+    it('should escape XML in comToastActivation arguments', async () => {
+      const packagingOptions: PackagingOptions = {
+        ...minimalPackagingOptions,
+        manifestVariables: {
+          ...minimalManifestVariables,
+          comToastActivation: {
+            toastActivatorClsid: '11111111-2222-3333-4444-555555555555',
+            arguments: '-x &amp;',
+          },
+        },
+      };
+      const appManifestIn = await manifest(packagingOptions);
+      expect(appManifestIn).toContain('Arguments="-x &amp;amp;"');
+    });
+  });
+
+  describe('normalizeToastActivatorClsid', () => {
+    it('normalizes GUID with or without braces to lowercase braced form', () => {
+      expect(normalizeToastActivatorClsid('{ABCDEF01-2345-6789-ABCD-EF0123456789}')).toBe(
+        '{abcdef01-2345-6789-abcd-ef0123456789}'
+      );
+      expect(normalizeToastActivatorClsid('ABCDEF01-2345-6789-ABCD-EF0123456789')).toBe(
+        '{abcdef01-2345-6789-abcd-ef0123456789}'
+      );
     });
   });
 });

--- a/test/unit/manifestation.spec.ts
+++ b/test/unit/manifestation.spec.ts
@@ -238,6 +238,23 @@ describe('manifestation', () => {
       );
     });
 
+    it('should escape XML in comToastActivation executable basename', async () => {
+      const packagingOptions: PackagingOptions = {
+        ...minimalPackagingOptions,
+        manifestVariables: {
+          ...minimalManifestVariables,
+          comToastActivation: {
+            toastActivatorClsid: '11111111-2222-3333-4444-555555555555',
+            executable: `my&app"test'exe.exe`,
+          },
+        },
+      };
+      const appManifestIn = await manifest(packagingOptions);
+      expect(appManifestIn).toContain(
+        'Executable="app\\my&amp;app&quot;test&apos;exe.exe"'
+      );
+    });
+
     it('should escape XML in comToastActivation arguments', async () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
@@ -251,6 +268,21 @@ describe('manifestation', () => {
       };
       const appManifestIn = await manifest(packagingOptions);
       expect(appManifestIn).toContain('Arguments="-x &amp;amp;"');
+    });
+
+    it('should escape apostrophes in comToastActivation arguments', async () => {
+      const packagingOptions: PackagingOptions = {
+        ...minimalPackagingOptions,
+        manifestVariables: {
+          ...minimalManifestVariables,
+          comToastActivation: {
+            toastActivatorClsid: '11111111-2222-3333-4444-555555555555',
+            arguments: "-x O'Brien",
+          },
+        },
+      };
+      const appManifestIn = await manifest(packagingOptions);
+      expect(appManifestIn).toContain('Arguments="-x O&apos;Brien"');
     });
   });
 

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -828,6 +828,37 @@ describe('utils', () => {
       expect(log.debug).toHaveBeenCalledWith('No WindowsKitVersion provided. Will try AppxManifest.xml min OS version next.');
     });
 
+    it('should skip app manifest block and use default binaries when no appManifest and no packageMinOSVersion', async () => {
+      const packagingOptions: PackagingOptions = {
+        ...minimalPackagingOptions,
+        appManifest: undefined,
+        manifestVariables: {
+          publisher: 'Electron',
+          packageIdentity: 'com.electron.app',
+          packageVersion: '1.0.0.0',
+          appExecutable: 'app.exe',
+          targetArch: 'x64',
+        } as any,
+      }
+      vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
+      const binaries = await locateMSIXTooling(packagingOptions);
+      expect(log.debug).toHaveBeenCalledWith('No information on WindowsKitVersion was provided, using default binaries. Checking if it exists....', expect.any(Object));
+      expect(binaries).toBeDefined();
+      expect(binaries?.makeAppx).toContain('10.0.26100.0');
+    });
+
+    it('should skip app manifest block when no appManifest and manifestVariables has no packageMinOSVersion', async () => {
+      const packagingOptions: PackagingOptions = {
+        appDir: 'C:\\app',
+        outputDir: 'C:\\out',
+        manifestVariables: undefined,
+      } as any
+      vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
+      const binaries = await locateMSIXTooling(packagingOptions);
+      expect(log.debug).toHaveBeenCalledWith('No information on WindowsKitVersion was provided, using default binaries. Checking if it exists....', expect.any(Object));
+      expect(binaries).toBeDefined();
+    });
+
     it('should return x64 binaries if the target arch is arm64 and the windows kit version is older than 10.0.22621.0', async () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
@@ -874,6 +905,23 @@ describe('utils', () => {
       }
       await locateMSIXTooling(packagingOptions, { manifestPackageArch: 'arm64' } as any);
       expect(log.error).toHaveBeenCalledWith("Couldn't find Windows Kit version in AppManifest.");
+    });
+
+    it('should use packageMinOSVersion from manifestVariables when appManifest is not set', async () => {
+      const packagingOptions: PackagingOptions = {
+        ...minimalPackagingOptions,
+        appManifest: undefined,
+        manifestVariables: {
+          ...minimalPackagingOptions.manifestVariables,
+          packageMinOSVersion: '10.0.22621.0',
+        } as any,
+      }
+      const binaries = await locateMSIXTooling(packagingOptions);
+      expect(binaries).toStrictEqual({
+        makeAppx: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\makeappx.exe',
+        makePri: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\makepri.exe',
+        makeCert: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\makecert.exe',
+        signTool: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\SignTool.exe'});
     });
 
     it('should return x64 binaries if the target arch is arm64 and the windows kit version is older than 10.0.22621.0', async () => {

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -258,6 +258,46 @@ describe('utils', () => {
         expect(log.error).toHaveBeenCalledWith('Neither package identity <packageIdentity> nor app manifest <appManifest> provided.', true);
       });
 
+      it('should throw an error if comToastActivation CLSID is invalid', async () => {
+        const packagingOptions: PackagingOptions = {
+          ...incompletePackagingOptions,
+          manifestVariables: {
+            packageVersion: '1.0.0',
+            publisher: 'Electron',
+            appExecutable: 'C:\\app\\app.exe',
+            targetArch: 'x64',
+            packageIdentity: 'com.app',
+            comToastActivation: { toastActivatorClsid: 'not-a-guid' },
+          } as any
+        }
+        await verifyOptions(packagingOptions);
+        expect(log.error).toHaveBeenCalledWith('comToastActivation.toastActivatorClsid must be a valid GUID.', true, { toastActivatorClsid: 'not-a-guid' });
+      });
+
+      it('should not error when comToastActivation CLSID is valid', async () => {
+        vi.mocked(log.error).mockClear();
+        const packagingOptions: PackagingOptions = {
+          ...incompletePackagingOptions,
+          manifestVariables: {
+            packageVersion: '1.0.0',
+            publisher: 'Electron',
+            appExecutable: 'C:\\app\\app.exe',
+            targetArch: 'x64',
+            packageIdentity: 'com.app',
+            comToastActivation: {
+              toastActivatorClsid: '{11111111-2222-3333-4444-555555555555}',
+            },
+          } as any,
+        };
+        vi.mocked(fs.exists).mockResolvedValue(true as any);
+        await verifyOptions(packagingOptions);
+        expect(log.error).not.toHaveBeenCalledWith(
+          'comToastActivation.toastActivatorClsid must be a valid GUID.',
+          true,
+          expect.anything()
+        );
+      });
+
       it('should warn if no publisher display name is provided', async () => {
         const packagingOptions: PackagingOptions = {
           ...incompletePackagingOptions,
@@ -305,7 +345,7 @@ describe('utils', () => {
         }
         vi.mocked(fs.exists).mockResolvedValue(true as any);
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Neither package min OS version <packageMinOSVersion> nor app manifest <appManifest> provided. Using default OS version 10.0.14393.0.');
+        expect(log.warn).toHaveBeenCalledWith('Neither package min OS version <packageMinOSVersion> nor app manifest <appManifest> provided. Using default OS version 10.0.19041.0.');
       });
 
       it('should warn if no packageMaxOSVersionTested is provided', async () => {
@@ -318,12 +358,12 @@ describe('utils', () => {
             targetArch: 'x64',
             packageIdentity: 'Electron.App',
             publisherDisplayName: 'Electron',
-            packageMinOSVersion: '10.0.14393.0',
+            packageMinOSVersion: '10.0.19041.0',
           } as any
         }
         vi.mocked(fs.exists).mockResolvedValue(true as any);
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Neither package max OS version tested <packageMaxOSVersionTested> nor app manifest <appManifest> provided. Using default OS version 10.0.14393.0.');
+        expect(log.warn).toHaveBeenCalledWith('Neither package max OS version tested <packageMaxOSVersionTested> nor app manifest <appManifest> provided. Using default OS version 10.0.19041.0.');
       });
 
       it('should warn if no appDisplayName is provided', async () => {
@@ -336,8 +376,8 @@ describe('utils', () => {
             targetArch: 'x64',
             packageIdentity: 'Electron.App',
             publisherDisplayName: 'Electron',
-            packageMinOSVersion: '10.0.14393.0',
-            packageMaxOSVersionTested: '10.0.14393.0',
+            packageMinOSVersion: '10.0.19041.0',
+            packageMaxOSVersionTested: '10.0.19041.0',
           } as any
         }
         vi.mocked(fs.exists).mockResolvedValue(true as any);
@@ -355,8 +395,8 @@ describe('utils', () => {
             targetArch: 'x64',
             packageIdentity: 'Electron.App',
             publisherDisplayName: 'Electron',
-            packageMinOSVersion: '10.0.14393.0',
-            packageMaxOSVersionTested: '10.0.14393.0',
+            packageMinOSVersion: '10.0.19041.0',
+            packageMaxOSVersionTested: '10.0.19041.0',
             appDisplayName: 'Electron',
           } as any
         }
@@ -375,8 +415,8 @@ describe('utils', () => {
             targetArch: 'x64',
             packageIdentity: 'Electron.App',
             publisherDisplayName: 'Electron',
-            packageMinOSVersion: '10.0.14393.0',
-            packageMaxOSVersionTested: '10.0.14393.0',
+            packageMinOSVersion: '10.0.19041.0',
+            packageMaxOSVersionTested: '10.0.19041.0',
             appDisplayName: 'Electron',
             packageDescription: 'Electron',
           } as any
@@ -557,8 +597,8 @@ describe('utils', () => {
           targetArch: 'x64',
           packageIdentity: 'Electron.App',
           publisherDisplayName: 'Electron',
-          packageMinOSVersion: '10.0.14393.0',
-          packageMaxOSVersionTested: '10.0.14393.0',
+          packageMinOSVersion: '10.0.19041.0',
+          packageMaxOSVersionTested: '10.0.19041.0',
           appDisplayName: 'app display name',
         } as any
       }
@@ -583,7 +623,7 @@ describe('utils', () => {
       }
 
       const manifestVariables : ManifestVariables =  {
-        manifestOsMinVersion: '10.0.14393.0',
+        manifestOsMinVersion: '10.0.19041.0',
         manifestAppName: 'app',
         manifestPackageArch: 'x64',
         manifestIsSparsePackage: false,


### PR DESCRIPTION
### Summary
Adds optional **`manifestVariables.comToastActivation`** so generated manifests can declare the packaged **COM server** (`windows.comServer`) and **toast notification activation** (`windows.toastNotificationActivation`) used by desktop apps for toast click handling, aligned with [Microsoft’s packaged desktop toast guidance](https://learn.microsoft.com/en-us/windows/apps/develop/notifications/app-notifications/send-local-toast-desktop-cpp-wrl).
**Only applies when the manifest is generated** (no `appManifest`); pre-built manifests are unchanged.
### What’s included
- **`static/templates/ComToastActivation.xml.in`** – Fragment for `<Extensions>` under `<Application>` (`com:Extension` + `desktop:Extension`).
- **`src/manifestation.ts`** – Merges fragment into the main template; `xmlns:com` stays in code; **`IgnorableNamespaces`** gains **`com`** and **`desktop`** when toast activation is enabled.
- **`ComToastActivationOptions`** (`types.ts`): `toastActivatorClsid` (required), optional `arguments` (default `-ToastActivated`), optional `executable` (basename; path in manifest is `app\{executable}`).
- **CLSID normalization** – Single `normalizeToastActivatorClsid(raw, braced?)`: default braced `{guid}`; **`braced: false`** for manifest (no braces, per MakeAppx/schema).
- **`verifyOptions`** – Validates `toastActivatorClsid` as a GUID when set.
- **Exports** – `ComToastActivationOptions` re-exported from `src/index.ts`.
- **Tests** – Unit coverage for manifest generation, GUID validation, and `normalizeToastActivatorClsid`; e2e packages with `comToastActivation` and asserts manifest content via **`readAppxManifestFromMsix`** in `test/e2e/utils/installer.ts`.
- **README** – Documents `comToastActivation` and example usage.
### Notes
- Template omits optional **DisplayName** attributes on `ExeServer` / `Class` to match minimal manifest samples.
### How to verify
```bash
npm run test:unit
npm run test:e2e  
```
