### PR TITLE
Fix For Bug Preventing Signing With MS Azure

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -229,7 +229,7 @@ export const makeProgramOptions = async (options: PackagingOptions, manifestVars
   let cert_cer = '';
   let cert_pass = '';
 
-  const createDevCert = sign && !options.windowsSignOptions?.certificateFile && !process.env.WINDOWS_CERTIFICATE_FILE;
+  const createDevCert = sign && !options.windowsSignOptions && !process.env.WINDOWS_CERTIFICATE_FILE;
   if(sign) {
     windowsSignOptions = options.windowsSignOptions || {files: [msix], certificateFile: '', certificatePassword: '', hashes: ["sha256"] as any };
     cert_pass = windowsSignOptions?.certificatePassword || process.env.WINDOWS_CERTIFICATE_PASSWORD || generatePassword();


### PR DESCRIPTION
Bringing in this fix:  https://github.com/electron-userland/electron-windows-msix/pull/28 which we need.

Similar to this other fix (but the above one is better): https://github.com/electron-userland/electron-windows-msix/pull/27



This fixes a bug that BLOCKS signing using MS Azure...


Because:  if createDevCert is true that passes in a a dev cert (in a pfx file) and passes the /p option (pfx file password) to signtool.exe which throws an error saying you can't do that and use the /dlib and /dmdf options used for Azure signing.

