### PR TITLE
chore: finish electron-userland rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MSIX packager for Electron Apps
-![electron_msix](https://github.com/bitdisaster/electron-windows-msix/assets/5191943/4321b39e-f4d8-4d2f-b6cb-78f7c27950ff)
+![electron_msix](https://github.com/electron-userland/electron-windows-msix/assets/5191943/4321b39e-f4d8-4d2f-b6cb-78f7c27950ff)
 
 
 Electron-Windows-MSIX is a module that lets you create an MSIX installer from a packaged Electron App.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bitdisaster/electron-windows-msix.git"
+    "url": "git+https://github.com/electron-userland/electron-windows-msix.git"
   },
   "keywords": [
     "MSIX",
@@ -27,9 +27,9 @@
   "author": "Jan Hannemann",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/bitdisaster/electron-windows-msix/issues"
+    "url": "https://github.com/electron-userland/electron-windows-msix/issues"
   },
-  "homepage": "https://github.com/bitdisaster/electron-windows-msix#readme",
+  "homepage": "https://github.com/electron-userland/electron-windows-msix#readme",
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
     "@vitest/coverage-istanbul": "3.2.4",


### PR DESCRIPTION
Cleaning these up now that this repo is in `electron-userland`.