### PR TITLE
chore: add code formatting and linting standards

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Node.js
-        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Lint
+        run: yarn lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+yarn lint-staged

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,6 @@ test/
 harness/
 out/
 coverage/
+.husky/
+.oxlintrc.json
+.oxfmtrc.json

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "singleQuote": true,
+  "printWidth": 100,
+  "sortPackageJson": false,
+  "ignorePatterns": [
+    "*.md",
+    "*.yml",
+    "*.yaml",
+    "test/**/fixtures/**",
+    "harness/fixtures/**",
+    "static/**"
+  ]
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["eslint", "typescript", "unicorn", "oxc", "import"],
+  "categories": { "correctness": "warn" },
+  "options": { "typeAware": true }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,3 @@
 {
-  "cSpell.words": [
-    "MSIX"
-  ]
+  "cSpell.words": ["MSIX"]
 }

--- a/harness/testing.cjs
+++ b/harness/testing.cjs
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const { packageMSIX } = require("../lib/index.ms");
+const { packageMSIX } = require('../lib/index.ms');
 
 // packageMSIX({
 //   appDir:  path.join(__dirname, '..\\test\\fixtures\\app-x64'),
@@ -45,7 +45,7 @@ const { packageMSIX } = require("../lib/index.ms");
 // });
 const main = async () => {
   const artifacts = await packageMSIX({
-    appDir:  path.join(__dirname, '\\..\\test\\e2e\\fixtures\\app-x64'),
+    appDir: path.join(__dirname, '\\..\\test\\e2e\\fixtures\\app-x64'),
     manifestVariables: {
       publisher: 'Electron MSIX',
       packageIdentity: 'com.electron.myapp',
@@ -58,7 +58,7 @@ const main = async () => {
   });
 
   console.log(artifacts);
-}
+};
 
 // {
 //   "manifestVariables": {
@@ -76,7 +76,7 @@ const main = async () => {
 //   "logLevel": "debug"
 // }
 
-main();
+void main();
 
 // packageMSIX({
 //     appDir:  path.join(__dirname, '..\\test\\fixtures\\app-arm64'),

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "prepublish": "npm run build",
+    "prepare": "husky",
     "build": "tsc",
+    "lint": "oxfmt --check . && oxlint",
+    "lint:fix": "oxfmt --write . && oxlint --fix",
     "test:e2e": "vitest run --config=./test/e2e/vitest.config.ts",
     "test:e2e:coverage": "vitest run --coverage --config=./test/e2e/vitest.config.ts",
     "harness": "tsc & node ./harness/testing.cjs",
@@ -33,8 +36,22 @@
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
     "@vitest/coverage-istanbul": "3.2.4",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
+    "oxfmt": "^0.44.0",
+    "oxlint": "^1.59.0",
+    "oxlint-tsgolint": "^0.20.0",
     "typescript": "^5.3.3",
     "vitest": "^3.2.4"
+  },
+  "lint-staged": {
+    "*.{js,ts,mjs}": [
+      "oxfmt --write",
+      "oxlint --fix"
+    ],
+    "*.{json,html}": [
+      "oxfmt --write"
+    ]
   },
   "dependencies": {
     "@electron/windows-sign": "^1.2.2",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,28 +1,24 @@
-import { sign as windowsSign, SignOptions } from "@electron/windows-sign";
+import { sign as windowsSign, SignOptions } from '@electron/windows-sign';
 import { spawn } from 'child_process';
 
-import { log } from "./logger";
-import { ProgramOptions } from "./types";
+import { log } from './logger';
+import { ProgramOptions } from './types';
 
-const  run = async (executable: string, args: Array<string>)  => {
+const run = async (executable: string, args: Array<string>) => {
   return new Promise<string>((resolve, reject) => {
     const proc = spawn(executable, args, {});
     log.debug(`Calling ${executable} with args`, args);
 
     const cleanOutData = (data: any) => {
-      return data
-      .toString()
-      .replace(/\r/g, '')
-      .replace(/\\\\/g, '\\')
-      .split('\n')
-    }
+      return data.toString().replace(/\r/g, '').replace(/\\\\/g, '\\').split('\n');
+    };
 
-    let stdout = "";
+    let stdout = '';
     proc.stdout.on('data', (data) => {
       stdout += data;
     });
 
-    let stderr = "";
+    let stderr = '';
     proc.stderr.on('data', (data) => {
       stderr += data;
     });
@@ -41,16 +37,15 @@ const  run = async (executable: string, args: Array<string>)  => {
         }
         return reject(
           new Error(
-            `Failed running ${executable} Exit Code: ${code} See previous errors for details`
-          )
+            `Failed running ${executable} Exit Code: ${code} See previous errors for details`,
+          ),
         );
-
       }
     });
 
     proc.stdin.end();
-  })
-}
+  });
+};
 
 export const getCertPublisher = async (cert: string, cert_pass: string) => {
   const args = [];
@@ -60,60 +55,64 @@ export const getCertPublisher = async (cert: string, cert_pass: string) => {
   const subjectRegex = /Subject:\s*(.*)/;
   const match = certDump.match(subjectRegex);
   const publisher = match ? match[1].trim() : null;
-  if(!publisher) {
+  if (!publisher) {
     log.error('Unable to find publisher in Cert');
   }
   return publisher;
-}
+};
 
 export const priConfig = async (program: ProgramOptions) => {
   const { makePri, priConfig, createPri } = program;
-  if(createPri) {
+  if (createPri) {
     const args = ['createconfig', '/cf', priConfig, '/dq', 'en-US'];
-    log.debug('Creating pri config.')
+    log.debug('Creating pri config.');
     await run(makePri, args);
   } else {
     log.debug('Skipping making pri config.');
   }
-}
+};
 
 export const pri = async (program: ProgramOptions) => {
   const { makePri, priConfig, layoutDir, priFile, appManifestLayout, createPri } = program;
-  if(createPri) {
-    log.debug('Making pri.')
-    const args = ['new', '/pr', layoutDir, '/cf', priConfig, '/mn', appManifestLayout, '/of', priFile, '/v'];
+  if (createPri) {
+    log.debug('Making pri.');
+    const args = [
+      'new',
+      '/pr',
+      layoutDir,
+      '/cf',
+      priConfig,
+      '/mn',
+      appManifestLayout,
+      '/of',
+      priFile,
+      '/v',
+    ];
     await run(makePri, args);
   } else {
     log.debug('Skipping making pri.');
   }
-}
+};
 
 export const make = async (program: ProgramOptions) => {
   const { makeMsix, layoutDir, msix, isSparsePackage, compress } = program;
-  const args = [
-    'pack',
-    '/d',
-    layoutDir,
-    '/p',
-    msix,
-    '/o',
-  ];
+  const args = ['pack', '/d', layoutDir, '/p', msix, '/o'];
 
-  if(isSparsePackage) {
+  if (isSparsePackage) {
     args.push('/nv');
   }
-  if(!compress) {
+  if (!compress) {
     args.push('/nc');
   }
   await run(makeMsix, args);
-}
+};
 
 export const sign = async (program: ProgramOptions) => {
-  if(program.sign) {
+  if (program.sign) {
     const signOptions = program.windowsSignOptions;
     log.debug('Signing with options', signOptions);
     await windowsSign(signOptions as SignOptions);
   } else {
     log.debug('Skipping signing.');
   }
-}
+};

--- a/src/cert.ts
+++ b/src/cert.ts
@@ -6,10 +6,10 @@ import { ProgramOptions } from './types';
 import { removePublisherPrefix } from './utils';
 
 export const ensureDevCert = async (programOptions: ProgramOptions) => {
-  if(programOptions.createDevCert) {
+  if (programOptions.createDevCert) {
     const template = fs.readFileSync(
       path.join(__dirname, '../static/templates/create_dev_cert.ps1.in'),
-      'utf-8'
+      'utf-8',
     );
     const publisherName = removePublisherPrefix(programOptions.publisher);
     const script = template
@@ -23,4 +23,4 @@ export const ensureDevCert = async (programOptions: ProgramOptions) => {
     await powershell(scriptPath);
     fs.unlinkSync(scriptPath);
   }
-}
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,33 @@
 import { make, pri, priConfig, sign } from './bin';
 import { ensureDevCert } from './cert';
 import { getManifestVariables } from './manifestation';
-import { type Artifacts, type ComToastActivationOptions, type ManifestGenerationVariables, type PackagingOptions, type WindowsSignOptions } from './types';
-import { createLayout, ensureFolders, makeProgramOptions, setLogLevel, verifyOptions } from './utils';
+import {
+  type Artifacts,
+  type ComToastActivationOptions,
+  type ManifestGenerationVariables,
+  type PackagingOptions,
+  type WindowsSignOptions,
+} from './types';
+import {
+  createLayout,
+  ensureFolders,
+  makeProgramOptions,
+  setLogLevel,
+  verifyOptions,
+} from './utils';
 
-export type { PackagingOptions, ManifestGenerationVariables, ComToastActivationOptions, Artifacts, WindowsSignOptions };
+export type {
+  PackagingOptions,
+  ManifestGenerationVariables,
+  ComToastActivationOptions,
+  Artifacts,
+  WindowsSignOptions,
+};
 
 export const packageMSIX = async (options: PackagingOptions) => {
   setLogLevel(options);
   await ensureFolders(options);
-  const manifestVars = await getManifestVariables(options)
+  const manifestVars = await getManifestVariables(options);
   await verifyOptions(options, manifestVars);
   const program = await makeProgramOptions(options, manifestVars);
   await createLayout(program);
@@ -22,4 +40,4 @@ export const packageMSIX = async (options: PackagingOptions) => {
   return {
     msixPackage: program.msix,
   };
-}
+};

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,41 +6,44 @@ export class log {
   private static log(level: 'info' | 'warn' | 'error' | 'debug', message: string, object?: any) {
     const logMessage = `${level}: ${message}`;
     let logObject = '';
-    if(object)
-      logObject = JSON.stringify(object, null, 2 ).replace(/\\r\\n/g, '\n').replace(/\\\\/g, '\\').replace(/\\\"/g, '"');
+    if (object)
+      logObject = JSON.stringify(object, null, 2)
+        .replace(/\\r\\n/g, '\n')
+        .replace(/\\\\/g, '\\')
+        .replace(/\\"/g, '"');
 
-    if(debug.enabled) {
+    if (debug.enabled) {
       debug('%s %s', logMessage, logObject);
-      return
+      return;
     }
 
-    if(level === 'debug' && !!globalThis.DEBUG) {
+    if (level === 'debug' && !!globalThis.DEBUG) {
       console.log(chalk.grey(logMessage));
-      if(object) {
+      if (object) {
         console.group();
         console.log(chalk.grey(logObject));
         console.groupEnd();
       }
     }
-    if(level === 'warn' && (!!globalThis.DEBUG || !!globalThis.SHOW_WARNINGS)) {
+    if (level === 'warn' && (!!globalThis.DEBUG || !!globalThis.SHOW_WARNINGS)) {
       console.log(chalk.yellow(logMessage));
-      if(object) {
+      if (object) {
         console.group();
         console.log(chalk.yellow(logObject));
         console.groupEnd();
       }
     }
-    if(level === 'error')  {
+    if (level === 'error') {
       console.log(chalk.red(logMessage));
-      if(object) {
+      if (object) {
         console.group();
         console.log(chalk.red(logObject));
         console.groupEnd();
       }
     }
-    if(level === 'info') {
+    if (level === 'info') {
       console.log(logMessage);
-      if(object) {
+      if (object) {
         console.group();
         console.log(logObject);
         console.groupEnd();
@@ -52,7 +55,7 @@ export class log {
   static warn = (message: string, object?: any) => this.log('warn', message, object);
   static error = (message: string, throwError: boolean = false, object?: any) => {
     this.log('error', message, object);
-    if(throwError) throw new Error(message);
-  }
+    if (throwError) throw new Error(message);
+  };
   static debug = (message: string, object?: any) => this.log('debug', message, object);
 }

--- a/src/manifestation.ts
+++ b/src/manifestation.ts
@@ -1,10 +1,9 @@
-import * as path from "path";
-import fs from "fs-extra";
+import * as path from 'path';
+import fs from 'fs-extra';
 
-import { ComToastActivationOptions, ManifestVariables, PackagingOptions } from "./types";
-import { removeFileExtension, removePublisherPrefix } from "./utils";
-import { ensureWindowsVersion } from "./win-version";
-
+import { ComToastActivationOptions, ManifestVariables, PackagingOptions } from './types';
+import { removeFileExtension, removePublisherPrefix } from './utils';
+import { ensureWindowsVersion } from './win-version';
 
 const DEFAULT_OS_VERSION = '10.0.19041.0';
 const DEFAULT_BACKGROUND_COLOR = 'transparent';
@@ -43,7 +42,7 @@ function getComToastExtensionsTemplate(): string {
 
 export function buildComToastActivationXml(
   opts: ComToastActivationOptions,
-  appExecutableFileName: string
+  appExecutableFileName: string,
 ): { comXmlns: string; ignorableCom: string; applicationExtensions: string } {
   const clsid = normalizeToastActivatorClsid(opts.toastActivatorClsid, false);
   const exeName = path.basename(opts.executable?.trim() || appExecutableFileName);
@@ -68,7 +67,9 @@ const getTemplate = () => {
   return content;
 };
 
-export const getManifestVariables = async (options: PackagingOptions): Promise < ManifestVariables > => {
+export const getManifestVariables = async (
+  options: PackagingOptions,
+): Promise<ManifestVariables> => {
   if (!options.appManifest) {
     return null;
   }
@@ -78,12 +79,12 @@ export const getManifestVariables = async (options: PackagingOptions): Promise <
   const appNameRegEx = /Executable="(.*?)"/s;
   const archRegEx = /ProcessorArchitecture="(.*?)"/s;
   const sparseRegex = /<uap10:AllowExternalContent>\s*true\s*<\/uap10:AllowExternalContent>/s;
-  const publisherRegex = /Publisher="(.*?)"/s
+  const publisherRegex = /Publisher="(.*?)"/s;
   let manifestOsMinVersion: string;
   let manifestAppName: string;
   let manifestPackageArch: string;
   let manifestIsSparsePackage = false;
-  let manifestPublisher: string
+  let manifestPublisher: string;
 
   let match = manifestXml.match(minWinVersionRegEx);
   if (match) {
@@ -116,10 +117,10 @@ export const getManifestVariables = async (options: PackagingOptions): Promise <
     manifestPackageArch,
     manifestIsSparsePackage,
     manifestPublisher,
-  }
+  };
 
   return manifestVariables;
-}
+};
 
 /**
  * Generates the AppxManifest.xml file from the options provided.
@@ -167,12 +168,18 @@ export const manifest = async (options: PackagingOptions) => {
     .replace(/{{IdentityName}}/g, packageIdentity)
     .replace(/{{AppDisplayName}}/g, appDisplayName || packageDisplayName || appName)
     .replace(/{{MinOSVersion}}/g, packageMinOSVersion || DEFAULT_OS_VERSION)
-    .replace(/{{MaxOSVersionTested}}/g, packageMaxOSVersionTested || packageMinOSVersion || DEFAULT_OS_VERSION)
+    .replace(
+      /{{MaxOSVersionTested}}/g,
+      packageMaxOSVersionTested || packageMinOSVersion || DEFAULT_OS_VERSION,
+    )
     .replace(/{{Version}}/g, version)
     .replace(/{{DisplayName}}/g, packageDisplayName || appDisplayName || appName)
     .replace(/{{PublisherName}}/g, publisherName)
     .replace(/{{PublisherDisplayName}}/g, publisherDisplayName || publisherName)
-    .replace(/{{PackageDescription}}/g, packageDescription || packageDisplayName || appDisplayName || appName)
+    .replace(
+      /{{PackageDescription}}/g,
+      packageDescription || packageDisplayName || appDisplayName || appName,
+    )
     .replace(/{{PackageBackgroundColor}}/g, packageBackgroundColor || DEFAULT_BACKGROUND_COLOR)
     .replace(/{{AppExecutable}}/g, appExecutable)
     .replace(/{{ProcessorArchitecture}}/g, targetArch)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { SignOptions } from "@electron/windows-sign";
+import type { SignOptions } from '@electron/windows-sign';
 
 /**
  * Modified SignOptions to make files and appDirectory optional. We can inject the MSIX package to the files array or the appDirectory if not provided.
@@ -19,72 +19,72 @@ export type WindowsSignOptions = Omit<SignOptions, 'files' | 'appDirectory'> & {
 
 export interface ManifestGenerationVariables {
   /**
-  * The identity of the MSIX package. This will be used to set the Identity attribute in the AppxManifest.xml.
-  * If a manifest is provided then this will be ignored.
-  */
-  packageIdentity : string;
+   * The identity of the MSIX package. This will be used to set the Identity attribute in the AppxManifest.xml.
+   * If a manifest is provided then this will be ignored.
+   */
+  packageIdentity: string;
   /**
-    * The publisher of the MSIX package. This will be used to create a default certificate if one is not provided.
-    * As well as the publisher name in the AppxManifest.xml. If a manifest is provided then this will be ignored.
-    */
-  publisher : string;
+   * The publisher of the MSIX package. This will be used to create a default certificate if one is not provided.
+   * As well as the publisher name in the AppxManifest.xml. If a manifest is provided then this will be ignored.
+   */
+  publisher: string;
   /**
-    * The display name of the publisher of the MSIX package. This will be used to set the PublisherDisplayName attribute in the AppxManifest.xml.
-    * If a manifest is provided then this will be ignored.
-    */
-  publisherDisplayName ? : string;
+   * The display name of the publisher of the MSIX package. This will be used to set the PublisherDisplayName attribute in the AppxManifest.xml.
+   * If a manifest is provided then this will be ignored.
+   */
+  publisherDisplayName?: string;
   /**
-    * The version of the MSIX package. This will be used to set the Version attribute in the AppxManifest.xml.
-    * If a manifest is provided then this will be ignored.
-    */
-  packageVersion : string;
+   * The version of the MSIX package. This will be used to set the Version attribute in the AppxManifest.xml.
+   * If a manifest is provided then this will be ignored.
+   */
+  packageVersion: string;
   /**
-    * The display name of the MSIX package. This will be used to set the DisplayName attribute in the AppxManifest.xml.
-    * If a manifest is provided then this will be ignored.
-    */
-  packageDisplayName ? : string;
+   * The display name of the MSIX package. This will be used to set the DisplayName attribute in the AppxManifest.xml.
+   * If a manifest is provided then this will be ignored.
+   */
+  packageDisplayName?: string;
   /**
-    * The description of the MSIX package. This will be used to set the Description attribute in the AppxManifest.xml.
-    * If a manifest is provided then this will be ignored.
-    */
-  packageDescription ? : string;
+   * The description of the MSIX package. This will be used to set the Description attribute in the AppxManifest.xml.
+   * If a manifest is provided then this will be ignored.
+   */
+  packageDescription?: string;
   /**
-    * The background color of the MSIX package. This will be used to set the BackgroundColor attribute in the VisualElements element in the AppxManifest.xml.
-    * If a manifest is provided then this will be ignored.
-    */
-  packageBackgroundColor ? : string;
+   * The background color of the MSIX package. This will be used to set the BackgroundColor attribute in the VisualElements element in the AppxManifest.xml.
+   * If a manifest is provided then this will be ignored.
+   */
+  packageBackgroundColor?: string;
   /**
-    * The executable of the MSIX package. This will be used to set the Executable attribute in the AppxManifest.xml.
-    * If a manifest is provided then this will be ignored.
-    */
-  appExecutable : string;
+   * The executable of the MSIX package. This will be used to set the Executable attribute in the AppxManifest.xml.
+   * If a manifest is provided then this will be ignored.
+   */
+  appExecutable: string;
   /**
-    * The name of the MSIX package. This will be used to set the DisplayName attribute in the VisualElements element in the AppxManifest.xml.
-    * If a manifest is provided then this will be ignored.
-  */
-  appDisplayName? : string;
+   * The name of the MSIX package. This will be used to set the DisplayName attribute in the VisualElements element in the AppxManifest.xml.
+   * If a manifest is provided then this will be ignored.
+   */
+  appDisplayName?: string;
   /**
-    * The target architecture of the MSIX package. This will be used to set the ProcessorArchitecture attribute in the AppxManifest.xml.
-    * If a manifest is provided then this will be ignored.
-    */
-  targetArch : 'x64' | 'arm64' | 'x86' | 'arm' | '*';
+   * The target architecture of the MSIX package. This will be used to set the ProcessorArchitecture attribute in the AppxManifest.xml.
+   * If a manifest is provided then this will be ignored.
+   */
+  targetArch: 'x64' | 'arm64' | 'x86' | 'arm' | '*';
   /**
-    * The minimum OS version the MSIX package requires. This will be used to set the MinVersion attribute in the TargetDeviceFamily element in the AppxManifest.xml.
-    * If a manifest is provided then this will be ignored.
-    */
-  packageMinOSVersion ? : string;
+   * The minimum OS version the MSIX package requires. This will be used to set the MinVersion attribute in the TargetDeviceFamily element in the AppxManifest.xml.
+   * If a manifest is provided then this will be ignored.
+   */
+  packageMinOSVersion?: string;
   /**
-    * The maximum OS version the MSIX package has been tested on. This will be used to set the MaxVersionTested attribute in the TargetDeviceFamily element in the AppxManifest.xml.
-    * If a manifest is provided then this will be ignored.
-    */
-  packageMaxOSVersionTested ? : string;
+   * The maximum OS version the MSIX package has been tested on. This will be used to set the MaxVersionTested attribute in the TargetDeviceFamily element in the AppxManifest.xml.
+   * If a manifest is provided then this will be ignored.
+   */
+  packageMaxOSVersionTested?: string;
   /**
    * When set, the generated manifest includes COM server registration and
    * `windows.toastNotificationActivation` so packaged desktop apps can handle
    * toast activations via the same CLSID.
    * Ignored when using a pre-built `appManifest` file.
    */
-  comToastActivation ? : ComToastActivationOptions;
+  comToastActivation?: ComToastActivationOptions;
 }
 
 /** Options for COM server + toast notification activation in AppxManifest. */
@@ -95,12 +95,12 @@ export interface ComToastActivationOptions {
    */
   toastActivatorClsid: string;
   /** `Arguments` on `com:ExeServer`. Default `-ToastActivated`. */
-  arguments ? : string;
+  arguments?: string;
   /**
    * Executable file name only (e.g. `MyApp.exe`). Defaults to `appExecutable` basename.
    * The manifest uses `app\\{executable}` to match the layout.
    */
-  executable ? : string;
+  executable?: string;
 }
 
 export interface PackagingOptions {
@@ -108,47 +108,47 @@ export interface PackagingOptions {
    * The manifest variables to generate the AppxManifest.xml for the package.
    * If a manifest is provided then this will be ignored.
    */
-  manifestVariables ? : ManifestGenerationVariables;
+  manifestVariables?: ManifestGenerationVariables;
   /**
    * The AppManifest.xml containing necessary declarations to build the MSIX
    */
-  appManifest ? : string;
+  appManifest?: string;
   /**
    * The folder containing the packaged Electron App. This parameter is required unless its building a Sparse MSIX.
    */
-  appDir ? : string;
+  appDir?: string;
   /** Optional assets used in AppManifest.xml. E.g. icons and tile images. If not provided then the default assets will be used. */
-  packageAssets ?: string;
+  packageAssets?: string;
   /** The output directory for the finished MSIX package. */
   outputDir: string;
   /** Optional name for the finished MSIX package file. If not provided a name will be derived from AppManifest.xml. */
-  packageName ? : string;
+  packageName?: string;
   /** Optional version of the WindowsKit to use. If WindowsKitPath is provide then it will trump this.
    * If neither WindowsKitVersion nor WindowsKitPath is provided then the Windows Kit path will be derived from the
    * OS Version specified in AppManifest.xml.
    */
-  windowsKitVersion ? : string;
+  windowsKitVersion?: string;
   /**
    * An optional full path to the WindowsKit. This path will trump both WindowsKitVersion and AppxManifest.
    */
-  windowsKitPath ? : string;
+  windowsKitPath?: string;
   /** Indicates whether to create Pri resource files. It will be enabled by default. */
-  createPri ? : boolean;
+  createPri?: boolean;
   /** Indicates whether to compress package files. It will be enabled by default. */
-  compress ? : boolean;
+  compress?: boolean;
   /**
    * Indicates whether to sign the MSIX package. It will be enabled by default. If cert or signParams are not provided then the package will be signed with a dev cert.
    * If sign is false then the package will not be signed.
    */
-  sign ? : boolean;
+  sign?: boolean;
   /**
    * Optional options for @electron/windows-sign. If present it will supersede signParams parameter.
    */
-  windowsSignOptions ? : WindowsSignOptions;
+  windowsSignOptions?: WindowsSignOptions;
   /**
    * Controls the level of logging
    */
-  logLevel ? : 'warn' | 'debug';
+  logLevel?: 'warn' | 'debug';
 }
 
 export interface ProgramOptions {
@@ -179,17 +179,16 @@ export interface ProgramOptions {
   publisher: string;
 }
 
-
 /**
  * The variables read from the provided AppxManifest.xml.
  */
 export type ManifestVariables = {
-  manifestOsMinVersion?: string,
-  manifestAppName: string,
-  manifestPackageArch: string,
-  manifestIsSparsePackage: boolean,
-  manifestPublisher: string
-}
+  manifestOsMinVersion?: string;
+  manifestAppName: string;
+  manifestPackageArch: string;
+  manifestIsSparsePackage: boolean;
+  manifestPublisher: string;
+};
 
 export interface Artifacts {
   msixPackage: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,12 +2,11 @@ import crypto from 'crypto';
 import fs from 'fs-extra';
 import path from 'path';
 
-import { log } from "./logger";
+import { log } from './logger';
 import { manifest } from './manifestation';
 import { getCertPublisher } from './bin';
-import { ManifestVariables, PackagingOptions, ProgramOptions, WindowsSignOptions } from "./types";
+import { ManifestVariables, PackagingOptions, ProgramOptions, WindowsSignOptions } from './types';
 import { isValidVersion, WindowsOSVersion } from './win-version';
-
 
 const DEFAULT_WIN_KIT_VERSION = '10.0.26100.0';
 const MIN_ARM_WIN_KIT_VERSION = '10.0.22621.0';
@@ -25,34 +24,38 @@ export const getBinaries = async (windowsKitPath: string) => {
     makeCert: path.join(windowsKitPath, MAKE_CERT_EXE),
   };
 
-  if(!(await fs.exists(binaries.makeAppx))) log.error(`MakeAppx binary ${MAKE_APPX_EXE} not found in:`, true, { windowsKitPath });
-  if(!(await fs.exists(binaries.makePri))) log.error(`MakePri binary ${MAKE_PRI_EXE} not found in:`, true, { windowsKitPath });
-  if(!(await fs.exists(binaries.signTool))) log.error(`SignTool binary ${SIGN_TOOL} not found in:`, true, { windowsKitPath });
-  if(!(await fs.exists(binaries.makeCert))) log.error(`MakeCert binary ${MAKE_CERT_EXE} not found in:`, true, { windowsKitPath });
+  if (!(await fs.exists(binaries.makeAppx)))
+    log.error(`MakeAppx binary ${MAKE_APPX_EXE} not found in:`, true, { windowsKitPath });
+  if (!(await fs.exists(binaries.makePri)))
+    log.error(`MakePri binary ${MAKE_PRI_EXE} not found in:`, true, { windowsKitPath });
+  if (!(await fs.exists(binaries.signTool)))
+    log.error(`SignTool binary ${SIGN_TOOL} not found in:`, true, { windowsKitPath });
+  if (!(await fs.exists(binaries.makeCert)))
+    log.error(`MakeCert binary ${MAKE_CERT_EXE} not found in:`, true, { windowsKitPath });
   return binaries;
-}
+};
 
 export const removeFileExtension = (executablePath: string) => {
-  if(!executablePath) return undefined;
+  if (!executablePath) return undefined;
   const executable = path.basename(executablePath);
-  return executable.replace(/\.[^\/.]+$/, "");
-}
+  return executable.replace(/\.[^/.]+$/, '');
+};
 
 export const removePublisherPrefix = (publisher: string) => {
-  return publisher.replace(/^CN=/, "");
-}
+  return publisher.replace(/^CN=/, '');
+};
 
 export const ensurePublisherPrefix = (publisher: string) => {
   return !publisher || publisher.startsWith('CN=') ? publisher : `CN=${publisher}`;
-}
+};
 
 export const ensureFolders = async (options: PackagingOptions) => {
   const outputDir = options.outputDir;
   const layoutDir = path.join(options.outputDir, 'msix_layout');
 
-  if(await fs.exists(outputDir)) {
+  if (await fs.exists(outputDir)) {
     log.debug('Output dir already exists. Making sure its empty.', { outputDir });
-    await fs.emptyDir(outputDir, );
+    await fs.emptyDir(outputDir);
   } else {
     log.debug('Output dir does not exists. Creating it.');
     await fs.ensureDir(outputDir);
@@ -62,75 +65,180 @@ export const ensureFolders = async (options: PackagingOptions) => {
   await fs.ensureDir(layoutDir);
 
   return { outputDir, layoutDir };
-}
+};
 
-export const verifyOptions = async (options: PackagingOptions, manifestVars?: ManifestVariables) => {
+export const verifyOptions = async (
+  options: PackagingOptions,
+  manifestVars?: ManifestVariables,
+) => {
   const { manifestIsSparsePackage, manifestPublisher } = manifestVars || {};
-  const publisher = manifestPublisher || ensurePublisherPrefix(options.manifestVariables?.publisher);
+  const publisher =
+    manifestPublisher || ensurePublisherPrefix(options.manifestVariables?.publisher);
   const windowsSignOptions = options.windowsSignOptions;
   const sign = options.sign !== undefined ? options.sign : true;
 
   let hasManifestParams = false;
-  log.debug('You are calling with following packaging options', options)
-  if(!options.appManifest && options.manifestVariables) {
-    if(!options.manifestVariables.packageVersion) log.error('Neither package version <packageVersion> nor app manifest <appManifest> provided.', true);
-    if(!isValidVersion(options.manifestVariables.packageVersion)) log.error('Package version <packageVersion> is not a semantic version.', true, { packageVersion: options.manifestVariables.packageVersion });
-    if(!options.manifestVariables.publisher) log.error('Neither publisher <publisher> nor app manifest <appManifest> provided.', true);
-    if(!options.manifestVariables.publisherDisplayName) log.warn('Neither publisher display name <publisherDisplayName> nor app manifest <appManifest> provided. Using publisher as display name.');
-    if(!options.manifestVariables.packageDisplayName) log.warn('Neither package display name <packageDisplayName> nor app manifest <appManifest> provided. Using app executable as display name.');
-    if(!options.manifestVariables.appExecutable) log.error('Neither app executable <appExecutable> nor app manifest <appManifest> provided.', true);
-    if(!options.manifestVariables.targetArch) log.error('Neither target architecture <targetArch> nor app manifest <appManifest> provided.', true);
-    if(!options.manifestVariables.packageMinOSVersion) log.warn('Neither package min OS version <packageMinOSVersion> nor app manifest <appManifest> provided. Using default OS version 10.0.19041.0.');
-    if(!options.manifestVariables.packageMaxOSVersionTested) log.warn('Neither package max OS version tested <packageMaxOSVersionTested> nor app manifest <appManifest> provided. Using default OS version 10.0.19041.0.');
-    if(!options.manifestVariables.packageIdentity) log.error('Neither package identity <packageIdentity> nor app manifest <appManifest> provided.', true);
-    if(!options.manifestVariables.appDisplayName) log.warn('Neither app display name <appDisplayName> nor app manifest <appManifest> provided. Using app executable as display name.');
-    if(!options.manifestVariables.packageDescription) log.warn('Neither package description <packageDescription> nor app manifest <appManifest> provided. Using app executable as description.');
-    if(!options.manifestVariables.packageBackgroundColor) log.warn('Neither package background color <packageBackgroundColor> nor app manifest <appManifest> provided. Using default background color transparent.');
+  log.debug('You are calling with following packaging options', options);
+  if (!options.appManifest && options.manifestVariables) {
+    if (!options.manifestVariables.packageVersion)
+      log.error(
+        'Neither package version <packageVersion> nor app manifest <appManifest> provided.',
+        true,
+      );
+    if (!isValidVersion(options.manifestVariables.packageVersion))
+      log.error('Package version <packageVersion> is not a semantic version.', true, {
+        packageVersion: options.manifestVariables.packageVersion,
+      });
+    if (!options.manifestVariables.publisher)
+      log.error('Neither publisher <publisher> nor app manifest <appManifest> provided.', true);
+    if (!options.manifestVariables.publisherDisplayName)
+      log.warn(
+        'Neither publisher display name <publisherDisplayName> nor app manifest <appManifest> provided. Using publisher as display name.',
+      );
+    if (!options.manifestVariables.packageDisplayName)
+      log.warn(
+        'Neither package display name <packageDisplayName> nor app manifest <appManifest> provided. Using app executable as display name.',
+      );
+    if (!options.manifestVariables.appExecutable)
+      log.error(
+        'Neither app executable <appExecutable> nor app manifest <appManifest> provided.',
+        true,
+      );
+    if (!options.manifestVariables.targetArch)
+      log.error(
+        'Neither target architecture <targetArch> nor app manifest <appManifest> provided.',
+        true,
+      );
+    if (!options.manifestVariables.packageMinOSVersion)
+      log.warn(
+        'Neither package min OS version <packageMinOSVersion> nor app manifest <appManifest> provided. Using default OS version 10.0.19041.0.',
+      );
+    if (!options.manifestVariables.packageMaxOSVersionTested)
+      log.warn(
+        'Neither package max OS version tested <packageMaxOSVersionTested> nor app manifest <appManifest> provided. Using default OS version 10.0.19041.0.',
+      );
+    if (!options.manifestVariables.packageIdentity)
+      log.error(
+        'Neither package identity <packageIdentity> nor app manifest <appManifest> provided.',
+        true,
+      );
+    if (!options.manifestVariables.appDisplayName)
+      log.warn(
+        'Neither app display name <appDisplayName> nor app manifest <appManifest> provided. Using app executable as display name.',
+      );
+    if (!options.manifestVariables.packageDescription)
+      log.warn(
+        'Neither package description <packageDescription> nor app manifest <appManifest> provided. Using app executable as description.',
+      );
+    if (!options.manifestVariables.packageBackgroundColor)
+      log.warn(
+        'Neither package background color <packageBackgroundColor> nor app manifest <appManifest> provided. Using default background color transparent.',
+      );
     const cta = options.manifestVariables.comToastActivation;
     if (cta?.toastActivatorClsid) {
       const guid = cta.toastActivatorClsid.trim().replace(/^\{|\}$/g, '');
-      const guidOk = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(guid);
+      const guidOk =
+        /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(guid);
       if (!guidOk) {
-        log.error('comToastActivation.toastActivatorClsid must be a valid GUID.', true, { toastActivatorClsid: cta.toastActivatorClsid });
+        log.error('comToastActivation.toastActivatorClsid must be a valid GUID.', true, {
+          toastActivatorClsid: cta.toastActivatorClsid,
+        });
       }
     }
     hasManifestParams = true;
   }
-  if(!hasManifestParams && !options.appManifest) log.error('Neither app manifest <appManifest> nor manifest variables <manifestVariables> provided.', true);
-  if(options.appManifest && !(await fs.exists(options.appManifest))) log.error('Path to application manifest <appManifest> does not exist.', true, { appManifest: options.appManifest });
-  if(!options.appDir && !manifestIsSparsePackage) log.error('Path to application <appDir> not provided.', true);
-  if(!(await fs.exists(options.appDir)) && !manifestIsSparsePackage) log.error('Path to application <appDir> does not exist.', true, { appDir: options.appDir });
-  if(!options.packageAssets) log.warn('Path to packages assets <packageAssets> not provided, using default assets.');
-  if(options.packageAssets && !(await fs.exists(options.packageAssets))) log.error('Path to packages assets provided but <packageAssets> does not exist.', true, { packageAssets: options.packageAssets });
-  if(sign) {
-    if(!windowsSignOptions || (!windowsSignOptions['appDirectory'] && (!windowsSignOptions['files'] || windowsSignOptions['files'].length === 0))) {
-      log.warn('Neither path to application <appDir> nor files <files> provided in windows sign options. Will add MSIX package to files.');
+  if (!hasManifestParams && !options.appManifest)
+    log.error(
+      'Neither app manifest <appManifest> nor manifest variables <manifestVariables> provided.',
+      true,
+    );
+  if (options.appManifest && !(await fs.exists(options.appManifest)))
+    log.error('Path to application manifest <appManifest> does not exist.', true, {
+      appManifest: options.appManifest,
+    });
+  if (!options.appDir && !manifestIsSparsePackage)
+    log.error('Path to application <appDir> not provided.', true);
+  if (!(await fs.exists(options.appDir)) && !manifestIsSparsePackage)
+    log.error('Path to application <appDir> does not exist.', true, { appDir: options.appDir });
+  if (!options.packageAssets)
+    log.warn('Path to packages assets <packageAssets> not provided, using default assets.');
+  if (options.packageAssets && !(await fs.exists(options.packageAssets)))
+    log.error('Path to packages assets provided but <packageAssets> does not exist.', true, {
+      packageAssets: options.packageAssets,
+    });
+  if (sign) {
+    if (
+      !windowsSignOptions ||
+      (!windowsSignOptions['appDirectory'] &&
+        (!windowsSignOptions['files'] || windowsSignOptions['files'].length === 0))
+    ) {
+      log.warn(
+        'Neither path to application <appDir> nor files <files> provided in windows sign options. Will add MSIX package to files.',
+      );
     }
 
-    if((!windowsSignOptions?.certificateFile && !process.env.WINDOWS_CERTIFICATE_FILE) && (windowsSignOptions?.certificatePassword || process.env.WINDOWS_CERTIFICATE_PASSWORD)) log.warn('Path to cert <certificateFile> or environment variable WINDOWS_CERTIFICATE_FILE not provided. A dev cert will be created with the provided password and the package will be signed with it!');
-    if(!windowsSignOptions?.certificateFile && (!windowsSignOptions?.certificatePassword && !process.env.WINDOWS_CERTIFICATE_PASSWORD)) log.warn('Path to cert <certificateFile> and cert password <certificatePassword> or environment variable WINDOWS_CERTIFICATE_PASSWORD not provided. A dev cert will be created with a random password and the package will be signed with it!');
-    if(windowsSignOptions?.certificateFile && !(await fs.exists(windowsSignOptions?.certificateFile))) log.error('Path to cert <certificateFile> does not exist.', true, { certificateFile: windowsSignOptions?.certificateFile });
-    if(windowsSignOptions?.certificateFile && !windowsSignOptions?.certificatePassword && !process.env.WINDOWS_CERTIFICATE_PASSWORD) log.warn('Cert password <certificatePassword> not provided.');
-    if(windowsSignOptions?.certificateFile && windowsSignOptions?.certificatePassword) {
-      const certPublisher = await getCertPublisher(windowsSignOptions?.certificateFile, windowsSignOptions?.certificatePassword);
-      if(publisher != certPublisher) log.error('The publisher in the manifest must match the publisher of the cert', false, {manifest_publisher: publisher, cert_publisher: certPublisher});
+    if (
+      !windowsSignOptions?.certificateFile &&
+      !process.env.WINDOWS_CERTIFICATE_FILE &&
+      (windowsSignOptions?.certificatePassword || process.env.WINDOWS_CERTIFICATE_PASSWORD)
+    )
+      log.warn(
+        'Path to cert <certificateFile> or environment variable WINDOWS_CERTIFICATE_FILE not provided. A dev cert will be created with the provided password and the package will be signed with it!',
+      );
+    if (
+      !windowsSignOptions?.certificateFile &&
+      !windowsSignOptions?.certificatePassword &&
+      !process.env.WINDOWS_CERTIFICATE_PASSWORD
+    )
+      log.warn(
+        'Path to cert <certificateFile> and cert password <certificatePassword> or environment variable WINDOWS_CERTIFICATE_PASSWORD not provided. A dev cert will be created with a random password and the package will be signed with it!',
+      );
+    if (
+      windowsSignOptions?.certificateFile &&
+      !(await fs.exists(windowsSignOptions?.certificateFile))
+    )
+      log.error('Path to cert <certificateFile> does not exist.', true, {
+        certificateFile: windowsSignOptions?.certificateFile,
+      });
+    if (
+      windowsSignOptions?.certificateFile &&
+      !windowsSignOptions?.certificatePassword &&
+      !process.env.WINDOWS_CERTIFICATE_PASSWORD
+    )
+      log.warn('Cert password <certificatePassword> not provided.');
+    if (windowsSignOptions?.certificateFile && windowsSignOptions?.certificatePassword) {
+      const certPublisher = await getCertPublisher(
+        windowsSignOptions?.certificateFile,
+        windowsSignOptions?.certificatePassword,
+      );
+      if (publisher != certPublisher)
+        log.error('The publisher in the manifest must match the publisher of the cert', false, {
+          manifest_publisher: publisher,
+          cert_publisher: certPublisher,
+        });
     }
   }
-}
+};
 
 export const setLogLevel = (options: PackagingOptions) => {
   const { logLevel } = options;
   globalThis.SHOW_WARNINGS = logLevel === 'warn';
   globalThis.DEBUG = logLevel === 'debug';
-}
+};
 
-export const locateMSIXTooling = async (options: PackagingOptions, manifestVars?: ManifestVariables) => {
+export const locateMSIXTooling = async (
+  options: PackagingOptions,
+  manifestVars?: ManifestVariables,
+) => {
   const { appManifest, windowsKitVersion, windowsKitPath } = options;
-  let arch =  process.env.PROCESSOR_ARCHITECTURE === 'ARM64' ? 'arm64' : 'x64';
+  let arch = process.env.PROCESSOR_ARCHITECTURE === 'ARM64' ? 'arm64' : 'x64';
 
-  if(windowsKitPath) {
-    log.debug('WindowsKitPath was provided and takes priority over WindowsKitVersion. Checking if it exists....', {windowsKitPath});
-    if(await fs.pathExists(windowsKitPath)) {
+  if (windowsKitPath) {
+    log.debug(
+      'WindowsKitPath was provided and takes priority over WindowsKitVersion. Checking if it exists....',
+      { windowsKitPath },
+    );
+    if (await fs.pathExists(windowsKitPath)) {
       const binaries = await getBinaries(windowsKitPath);
       log.debug('WindowsKitPath exists. Getting binary paths.', binaries);
       return binaries;
@@ -141,60 +249,86 @@ export const locateMSIXTooling = async (options: PackagingOptions, manifestVars?
     log.debug('No WindowsKitPath provided. Will try WindowsKitVersion next.');
   }
 
-  if(windowsKitVersion) {
+  if (windowsKitVersion) {
     // Older versions than WinKit 10.0.22621.0 for ARM are missing the makeAppx.exe and we will fall back to x64 in that case.
-    if(WindowsOSVersion.IsOlder(windowsKitVersion, MIN_ARM_WIN_KIT_VERSION) && arch === 'arm64') {
+    if (WindowsOSVersion.IsOlder(windowsKitVersion, MIN_ARM_WIN_KIT_VERSION) && arch === 'arm64') {
       arch = 'x64';
     }
-    log.debug('WindowsKitVersion was provided and takes priority over AppxManifest. Checking if it exists....', {windowsKitVersion});
+    log.debug(
+      'WindowsKitVersion was provided and takes priority over AppxManifest. Checking if it exists....',
+      { windowsKitVersion },
+    );
     const windowsKitPathExec = path.join(WIN_KIT_BIN_PATH, windowsKitVersion, arch);
 
-    if(await fs.pathExists(windowsKitPathExec)) {
+    if (await fs.pathExists(windowsKitPathExec)) {
       const binaries = await getBinaries(windowsKitPathExec);
       log.debug(`WindowsKit version ${windowsKitVersion} exists. Getting binary paths.`, binaries);
       return binaries;
-    }else {
+    } else {
       log.error('WindowsKitVersion was provided but does not exist.', true, windowsKitPathExec);
     }
   } else {
     log.debug('No WindowsKitVersion provided. Will try AppxManifest.xml min OS version next.');
   }
 
-  if(appManifest || options.manifestVariables?.packageMinOSVersion) {
+  if (appManifest || options.manifestVariables?.packageMinOSVersion) {
     let { manifestOsMinVersion } = manifestVars || {};
     manifestOsMinVersion = manifestOsMinVersion || options.manifestVariables?.packageMinOSVersion;
-    log.debug('WindowsKitVersion was derived from OSMinVersion of the AppxManifest. Checking if it exists....', {manifestOsMinVersion});
+    log.debug(
+      'WindowsKitVersion was derived from OSMinVersion of the AppxManifest. Checking if it exists....',
+      { manifestOsMinVersion },
+    );
     if (manifestOsMinVersion) {
       // Older versions than WinKit 10.0.22621.0 for ARM are missing the makeAppx.exe and we will fall back to x64 in that case.
-      if(WindowsOSVersion.IsOlder(manifestOsMinVersion, MIN_ARM_WIN_KIT_VERSION) && arch === 'arm64') {
+      if (
+        WindowsOSVersion.IsOlder(manifestOsMinVersion, MIN_ARM_WIN_KIT_VERSION) &&
+        arch === 'arm64'
+      ) {
         arch = 'x64';
       }
-      log.debug('WindowsKitVersion was derived from OSMinVersion of the AppxManifest. Checking if it exists....', {windowsKitVersion});
+      log.debug(
+        'WindowsKitVersion was derived from OSMinVersion of the AppxManifest. Checking if it exists....',
+        { windowsKitVersion },
+      );
       const windowsKitPathExec = path.join(WIN_KIT_BIN_PATH, manifestOsMinVersion, arch);
 
-      if(await fs.pathExists(windowsKitPathExec)) {
+      if (await fs.pathExists(windowsKitPathExec)) {
         const binaries = await getBinaries(windowsKitPathExec);
-        log.debug(`WindowsKit version ${windowsKitVersion} from AppxManifest exists. Getting binary paths.`, binaries);
+        log.debug(
+          `WindowsKit version ${windowsKitVersion} from AppxManifest exists. Getting binary paths.`,
+          binaries,
+        );
         return binaries;
       } else {
-        log.error('WindowsKitVersion read from AppManifest but WindowsKit does not exist.', true, windowsKitPathExec);
+        log.error(
+          'WindowsKitVersion read from AppManifest but WindowsKit does not exist.',
+          true,
+          windowsKitPathExec,
+        );
       }
     } else {
       log.error("Couldn't find Windows Kit version in AppManifest.");
     }
   }
 
-  log.debug('No information on WindowsKitVersion was provided, using default binaries. Checking if it exists....', {windowsKitVersion});
+  log.debug(
+    'No information on WindowsKitVersion was provided, using default binaries. Checking if it exists....',
+    { windowsKitVersion },
+  );
   const windowsKitPathExec = path.join(WIN_KIT_BIN_PATH, DEFAULT_WIN_KIT_VERSION, arch);
-  if(await fs.pathExists(windowsKitPathExec)) {
+  if (await fs.pathExists(windowsKitPathExec)) {
     const binaries = await getBinaries(windowsKitPathExec);
     log.debug(`Getting binary paths from default WindowsKit path.`, binaries);
     return binaries;
   } else {
-    log.error('No information on WindowsKitVersion was provided and default WindowsKit path does not exist.', true, windowsKitPathExec);
+    log.error(
+      'No information on WindowsKitVersion was provided and default WindowsKit path does not exist.',
+      true,
+      windowsKitPathExec,
+    );
   }
   log.error('Unable to locate MSIX Tooling. Giving up!', true);
-}
+};
 
 /**
  * Generates a secure random password.
@@ -215,49 +349,68 @@ function generatePassword() {
   return password;
 }
 
-export const makeProgramOptions = async (options: PackagingOptions, manifestVars?: ManifestVariables) =>{
-  const { makeAppx, makePri, signTool, makeCert} = await locateMSIXTooling(options, manifestVars);
+export const makeProgramOptions = async (
+  options: PackagingOptions,
+  manifestVars?: ManifestVariables,
+) => {
+  const { makeAppx, makePri, signTool, makeCert } = await locateMSIXTooling(options, manifestVars);
   const { outputDir, layoutDir } = await ensureFolders(options);
-  const { manifestAppName, manifestPackageArch, manifestIsSparsePackage, manifestPublisher } = manifestVars || {};
-  const appName = manifestAppName || removeFileExtension(options.manifestVariables?.appExecutable) || 'app';
+  const { manifestAppName, manifestPackageArch, manifestIsSparsePackage, manifestPublisher } =
+    manifestVars || {};
+  const appName =
+    manifestAppName || removeFileExtension(options.manifestVariables?.appExecutable) || 'app';
   const packageArch = manifestPackageArch || options.manifestVariables?.targetArch;
   const isSparsePackage = manifestIsSparsePackage || false;
-  const msixPackageName = options.packageName || (packageArch ? `${appName}_${packageArch}.msix` : `${appName}.msix`);
+  const msixPackageName =
+    options.packageName || (packageArch ? `${appName}_${packageArch}.msix` : `${appName}.msix`);
   const msix = path.join(outputDir, msixPackageName);
   const appManifestLayout = path.join(layoutDir, `AppxManifest.xml`);
   const assetsLayout = path.join(layoutDir, `assets`);
   const appLayout = path.join(layoutDir, `app`);
   const priConfig = path.join(layoutDir, 'priconfig.xml');
-  const priFile =  path.join(layoutDir, 'resources.pri');
+  const priFile = path.join(layoutDir, 'resources.pri');
   const createPri = options.createPri !== undefined ? options.createPri : true;
   const compress = options.compress !== undefined ? options.compress : true;
   const publisher = options.manifestVariables?.publisher || manifestPublisher || '';
   const sign = options.sign !== undefined ? options.sign : true;
-  let windowsSignOptions: WindowsSignOptions
+  let windowsSignOptions: WindowsSignOptions;
   let cert_pfx = windowsSignOptions?.certificateFile || '';
   let cert_cer = '';
   let cert_pass = '';
 
-  const createDevCert = sign && !options.windowsSignOptions?.certificateFile && !process.env.WINDOWS_CERTIFICATE_FILE;
-  if(sign) {
-    windowsSignOptions = options.windowsSignOptions || {files: [msix], certificateFile: '', certificatePassword: '', hashes: ["sha256"] as any };
-    cert_pass = windowsSignOptions?.certificatePassword || process.env.WINDOWS_CERTIFICATE_PASSWORD || generatePassword();
+  const createDevCert =
+    sign && !options.windowsSignOptions?.certificateFile && !process.env.WINDOWS_CERTIFICATE_FILE;
+  if (sign) {
+    windowsSignOptions = options.windowsSignOptions || {
+      files: [msix],
+      certificateFile: '',
+      certificatePassword: '',
+      hashes: ['sha256'] as any,
+    };
+    cert_pass =
+      windowsSignOptions?.certificatePassword ||
+      process.env.WINDOWS_CERTIFICATE_PASSWORD ||
+      generatePassword();
     if (!windowsSignOptions.hashes || windowsSignOptions.hashes.length === 0) {
       windowsSignOptions.hashes = ['sha256'] as any;
     }
-    if(createDevCert) {
+    if (createDevCert) {
       cert_pfx = path.join(outputDir, 'dev_cert.pfx');
       cert_cer = path.join(outputDir, 'dev_cert.cer');
       windowsSignOptions[`certificateFile`] = cert_pfx;
       windowsSignOptions[`certificatePassword`] = cert_pass;
     }
-    if(options.logLevel === 'debug') {
+    if (options.logLevel === 'debug') {
       windowsSignOptions[`debug`] = true;
     }
 
-    const hasAppDirectorySet = 'appDirectory' in windowsSignOptions && windowsSignOptions.appDirectory;
-    const hasFilesSet = 'files' in windowsSignOptions && windowsSignOptions.files && windowsSignOptions.files.length > 0;
-    if(!hasAppDirectorySet && !hasFilesSet) {
+    const hasAppDirectorySet =
+      'appDirectory' in windowsSignOptions && windowsSignOptions.appDirectory;
+    const hasFilesSet =
+      'files' in windowsSignOptions &&
+      windowsSignOptions.files &&
+      windowsSignOptions.files.length > 0;
+    if (!hasAppDirectorySet && !hasFilesSet) {
       windowsSignOptions[`files`] = [msix];
     }
   }
@@ -290,16 +443,16 @@ export const makeProgramOptions = async (options: PackagingOptions, manifestVars
     windowsSignOptions,
     createDevCert,
     publisher,
-  }
+  };
 
   log.debug('Program options', program);
   return program;
-}
+};
 
 export const createLayout = async (program: ProgramOptions) => {
   await fs.writeFile(program.appManifestLayout, program.appManifestIn);
   await fs.copy(program.assetsIn, program.assetsLayout);
-  if(!program.isSparsePackage) {
+  if (!program.isSparsePackage) {
     await fs.copy(program.appDir, program.appLayout);
   }
-}
+};

--- a/src/win-version.ts
+++ b/src/win-version.ts
@@ -1,55 +1,55 @@
 export class WindowsOSVersion {
-    public major: number;
-    public minor: number;
-    public patch: number;
-    public build: number;
+  public major: number;
+  public minor: number;
+  public patch: number;
+  public build: number;
 
-    constructor(version: string) {
-        const array = version.split('.');
-        if(array.length != 4) {
-            throw new Error(`Invalid Windows version string. {${version}}`);
-        }
-        this.major = Number.parseInt(array[0], 10);
-        this.minor = Number.parseInt(array[1], 10);
-        this.patch = Number.parseInt(array[2], 10);
-        this.build = Number.parseInt(array[3], 10);
+  constructor(version: string) {
+    const array = version.split('.');
+    if (array.length != 4) {
+      throw new Error(`Invalid Windows version string. {${version}}`);
     }
+    this.major = Number.parseInt(array[0], 10);
+    this.minor = Number.parseInt(array[1], 10);
+    this.patch = Number.parseInt(array[2], 10);
+    this.build = Number.parseInt(array[3], 10);
+  }
 
-    public toString = () : string => `${this.major}.${this.minor}.${this.patch}.${this.build}`;
+  public toString = (): string => `${this.major}.${this.minor}.${this.patch}.${this.build}`;
 
-    public equals(other: WindowsOSVersion) {
-        if(this.major < other.major) return -1;
-        if(this.major > other.major) return 1;
+  public equals(other: WindowsOSVersion) {
+    if (this.major < other.major) return -1;
+    if (this.major > other.major) return 1;
 
-        if(this.minor < other.minor) return -1;
-        if(this.minor > other.minor) return 1;
+    if (this.minor < other.minor) return -1;
+    if (this.minor > other.minor) return 1;
 
-        if(this.patch < other.patch) return -1;
-        if(this.patch > other.patch) return 1;
+    if (this.patch < other.patch) return -1;
+    if (this.patch > other.patch) return 1;
 
-        if(this.build < other.build) return -1;
-        if(this.build > other.build) return 1;
+    if (this.build < other.build) return -1;
+    if (this.build > other.build) return 1;
 
-        return 0;
-    }
+    return 0;
+  }
 
-    public static IsOlder(v1: string, v2: string) {
-        const wv1 = new WindowsOSVersion(v1);
-        const wv2 = new WindowsOSVersion(v2);
-        return wv1.equals(wv2) === -1;
-    }
+  public static IsOlder(v1: string, v2: string) {
+    const wv1 = new WindowsOSVersion(v1);
+    const wv2 = new WindowsOSVersion(v2);
+    return wv1.equals(wv2) === -1;
+  }
 
-    public static IsNewer(v1: string, v2: string) {
-        const wv1 = new WindowsOSVersion(v1);
-        const wv2 = new WindowsOSVersion(v2);
-        return wv1.equals(wv2) === 1;
-    }
+  public static IsNewer(v1: string, v2: string) {
+    const wv1 = new WindowsOSVersion(v1);
+    const wv2 = new WindowsOSVersion(v2);
+    return wv1.equals(wv2) === 1;
+  }
 
-    public static IsSame(v1: string, v2: string) {
-        const wv1 = new WindowsOSVersion(v1);
-        const wv2 = new WindowsOSVersion(v2);
-        return wv1.equals(wv2) === 0;
-    }
+  public static IsSame(v1: string, v2: string) {
+    const wv1 = new WindowsOSVersion(v1);
+    const wv2 = new WindowsOSVersion(v2);
+    return wv1.equals(wv2) === 0;
+  }
 }
 
 /**
@@ -58,10 +58,11 @@ export class WindowsOSVersion {
  * @returns True if the version string is a semantic version, false otherwise.
  */
 export const isValidVersion = (version: string) => {
-  const semVerRegex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+  const semVerRegex =
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
   const windowsVerRegex = /^\d+\.\d+\.\d+\.\d+$/;
   return semVerRegex.test(version) || windowsVerRegex.test(version);
-}
+};
 
 /**
  * Ensures a semantic version string is converted to a Windows version string if it contains a prerelease version.
@@ -69,19 +70,17 @@ export const isValidVersion = (version: string) => {
  * @returns The normalized version string.
  */
 export const ensureWindowsVersion = (semanticVersion: string): string => {
-    const semVerRegex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+  if (semanticVersion.match(/^\d+\.\d+\.\d+\.\d+$/)) {
+    return semanticVersion;
+  }
 
-    if(semanticVersion.match(/^\d+\.\d+\.\d+\.\d+$/)) {
-        return semanticVersion;
-    }
+  if (semanticVersion.match(/^\d+\.\d+\.\d+$/)) {
+    return `${semanticVersion}.0`;
+  }
 
-    if(semanticVersion.match(/^\d+\.\d+\.\d+$/)) {
-        return `${semanticVersion}.0`;
-    }
+  if (!isValidVersion(semanticVersion)) {
+    throw new Error(`Invalid semantic version string. {${semanticVersion}}`);
+  }
 
-    if(!isValidVersion(semanticVersion)) {
-       throw new Error(`Invalid semantic version string. {${semanticVersion}}`);
-    }
-
-    return semanticVersion.replace(/[-+].*/, '.0');
-}
+  return semanticVersion.replace(/[-+].*/, '.0');
+};

--- a/test/e2e/installation.spec.ts
+++ b/test/e2e/installation.spec.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
-import path from "path";
-import { describe, it, expect, beforeAll } from "vitest";
+import path from 'path';
+import { describe, it, expect, beforeAll } from 'vitest';
 
-import { packageMSIX } from "../../src/index";
+import { packageMSIX } from '../../src/index';
 import { installDevCert } from './utils/cert';
 import { checkInstall, installMSIX, uninstallMSIX } from './utils/installer';
 import { powershell } from '../../src/powershell';

--- a/test/e2e/packaging.spec.ts
+++ b/test/e2e/packaging.spec.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs';
-import path from "path";
-import { describe, it, expect, beforeAll } from "vitest";
+import path from 'path';
+import { describe, it, expect, beforeAll } from 'vitest';
 
-import { packageMSIX } from "../../src/index";
+import { packageMSIX } from '../../src/index';
 import { installDevCert } from './utils/cert';
 import { readAppxManifestFromMsix } from './utils/installer';
 
@@ -72,15 +72,15 @@ describe('packaging', () => {
     const msixPath = path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix');
     expect(fs.existsSync(msixPath)).toBe(true);
     const manifestXml = await readAppxManifestFromMsix(msixPath);
-    expect(manifestXml).toContain('xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"');
+    expect(manifestXml).toContain(
+      'xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"',
+    );
     expect(manifestXml).toMatch(/IgnorableNamespaces="[^"]*\bcom\b/);
     expect(manifestXml).toContain('Category="windows.comServer"');
     expect(manifestXml).toContain('Category="windows.toastNotificationActivation"');
-    expect(manifestXml).toContain(
-      'ToastActivatorCLSID="a0e0e0e0-e0e0-4ae0-a0e0-e0e0e0e0e0e0"'
-    );
+    expect(manifestXml).toContain('ToastActivatorCLSID="a0e0e0e0-e0e0-4ae0-a0e0-e0e0e0e0e0e0"');
     expect(manifestXml).toMatch(
-      /<com:ExeServer[^>]*Executable="app\\hellomsix\.exe"[^>]*Arguments="-ToastActivated"/
+      /<com:ExeServer[^>]*Executable="app\\hellomsix\.exe"[^>]*Arguments="-ToastActivated"/,
     );
   });
 
@@ -144,7 +144,9 @@ describe('packaging', () => {
         appExecutable: 'hellomsix.exe',
         targetArch: 'x64',
       },
-      windowsKitPath: path.join('C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\x64'),
+      windowsKitPath: path.join(
+        'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\x64',
+      ),
     });
     expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(true);
   });
@@ -168,7 +170,9 @@ describe('packaging', () => {
       expect(e).toBeDefined();
       expect(e.message).toBe('The WindowsKitPath was provided but does not exist.');
     }
-    expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(false);
+    expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(
+      false,
+    );
   });
 
   it('should package with an explicit windows kit version', async () => {
@@ -206,7 +210,9 @@ describe('packaging', () => {
       expect(e).toBeDefined();
       expect(e.message).toBe('WindowsKitVersion was provided but does not exist.');
     }
-    expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(false);
+    expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(
+      false,
+    );
   });
 
   it('should package with windows kit version derived from manifest min version', async () => {
@@ -242,9 +248,13 @@ describe('packaging', () => {
       });
     } catch (e) {
       expect(e).toBeDefined();
-      expect(e.message).toBe('WindowsKitVersion read from AppManifest but WindowsKit does not exist.');
+      expect(e.message).toBe(
+        'WindowsKitVersion read from AppManifest but WindowsKit does not exist.',
+      );
     }
-    expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(false);
+    expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(
+      false,
+    );
   });
 
   it('should package without a given windows kit version or path', async () => {
@@ -265,7 +275,7 @@ describe('packaging', () => {
 
   it('should package if out dir does not exist', async () => {
     fs.rmSync(path.join(__dirname, '..', '..', 'out'), { recursive: true, force: true });
-     await packageMSIX({
+    await packageMSIX({
       appDir: path.join(__dirname, 'fixtures', 'app-x64'),
       outputDir: path.join(__dirname, '..', '..', 'out'),
       appManifest: path.join(__dirname, 'fixtures', 'AppxManifest_x64.xml'),
@@ -322,13 +332,17 @@ describe('packaging', () => {
       });
     } catch (e) {
       expect(e).toBeDefined();
-      expect(e.message).toBe('Neither app manifest <appManifest> nor manifest variables <manifestVariables> provided.');
+      expect(e.message).toBe(
+        'Neither app manifest <appManifest> nor manifest variables <manifestVariables> provided.',
+      );
     }
-    expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(false);
+    expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(
+      false,
+    );
   });
 
   it('should package without compression', async () => {
-     await packageMSIX({
+    await packageMSIX({
       appDir: path.join(__dirname, 'fixtures', 'app-x64'),
       outputDir: path.join(__dirname, '..', '..', 'out'),
       appManifest: path.join(__dirname, 'fixtures', 'AppxManifest_x64.xml'),

--- a/test/e2e/signing.spec.ts
+++ b/test/e2e/signing.spec.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs';
-import path from "path";
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import path from 'path';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 
-import { packageMSIX } from "../../src/index";
+import { packageMSIX } from '../../src/index';
 import { getCertStatus, getCertSubject, installDevCert } from './utils/cert';
 
 describe('signing', () => {
@@ -26,17 +26,23 @@ describe('signing', () => {
           certificatePassword: 'Password123',
         },
       });
-      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(true);
+      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(
+        true,
+      );
     });
 
     it('should sign the msix', async () => {
-      const certStatus = await getCertStatus(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'));
-      expect(certStatus).toBe('Valid')
+      const certStatus = await getCertStatus(
+        path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'),
+      );
+      expect(certStatus).toBe('Valid');
     });
 
     it('should the cert should have the correct subject', async () => {
-      const certSubject = await getCertSubject(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'));
-      expect(certSubject).toBe('CN=Electron MSIX')
+      const certSubject = await getCertSubject(
+        path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'),
+      );
+      expect(certSubject).toBe('CN=Electron MSIX');
     });
 
     it('should not sign the app if sign is set to false', async () => {
@@ -50,8 +56,12 @@ describe('signing', () => {
         },
         sign: false,
       });
-      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(true);
-      const certStatus = await getCertStatus(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'));
+      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(
+        true,
+      );
+      const certStatus = await getCertStatus(
+        path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'),
+      );
       expect(certStatus).toBe('NotSigned');
     });
 
@@ -63,13 +73,15 @@ describe('signing', () => {
         windowsSignOptions: {
           certificateFile: path.join(__dirname, 'fixtures', 'MSIXDevCert.pfx'),
           certificatePassword: 'Password123',
-          signWithParams: [
-            '/v',
-          ],
+          signWithParams: ['/v'],
         },
       });
-      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(true);
-      const certStatus = await getCertStatus(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'));
+      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(
+        true,
+      );
+      const certStatus = await getCertStatus(
+        path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'),
+      );
       expect(certStatus).toBe('Valid');
     });
 
@@ -81,8 +93,12 @@ describe('signing', () => {
         outputDir: path.join(__dirname, '..', '..', 'out'),
         appManifest: path.join(__dirname, 'fixtures', 'AppxManifest_x64.xml'),
       });
-      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(true);
-      const certStatus = await getCertStatus(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'));
+      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(
+        true,
+      );
+      const certStatus = await getCertStatus(
+        path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'),
+      );
       expect(certStatus).toBe('Valid');
     });
 
@@ -93,11 +109,16 @@ describe('signing', () => {
         outputDir: path.join(__dirname, '..', '..', 'out'),
         appManifest: path.join(__dirname, 'fixtures', 'AppxManifest_x64.xml'),
         windowsSignOptions: {
-          certificateFile: path.join(__dirname, 'fixtures', 'MSIXDevCert.pfx'),          certificatePassword: 'Password123',
+          certificateFile: path.join(__dirname, 'fixtures', 'MSIXDevCert.pfx'),
+          certificatePassword: 'Password123',
         },
       });
-      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(true);
-      const certStatus = await getCertStatus(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'));
+      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(
+        true,
+      );
+      const certStatus = await getCertStatus(
+        path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'),
+      );
       expect(certStatus).toBe('Valid');
     });
 
@@ -111,8 +132,12 @@ describe('signing', () => {
           certificatePassword: 'Password123',
         },
       });
-      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(true);
-      const certStatus = await getCertStatus(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'));
+      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(
+        true,
+      );
+      const certStatus = await getCertStatus(
+        path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'),
+      );
       expect(certStatus).toBe('Valid');
     });
   });
@@ -131,17 +156,23 @@ describe('signing', () => {
         },
         windowsKitVersion: '10.0.26100.0',
       });
-      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(true);
+      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(
+        true,
+      );
     });
 
     it('should sign the msix', async () => {
-      const certStatus = await getCertStatus(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'));
-      expect(certStatus).not.toBe('NotSigned')
+      const certStatus = await getCertStatus(
+        path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'),
+      );
+      expect(certStatus).not.toBe('NotSigned');
     });
 
     it('should have the correct subject', async () => {
-      const certSubject = await getCertSubject(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'));
-      expect(certSubject).toBe('CN=Dev Publisher')
+      const certSubject = await getCertSubject(
+        path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'),
+      );
+      expect(certSubject).toBe('CN=Dev Publisher');
     });
 
     it('should use the generated dev cert with the provided password via environment variables', async () => {
@@ -152,8 +183,12 @@ describe('signing', () => {
         appManifest: path.join(__dirname, 'fixtures', 'AppxManifest_x64.xml'),
         logLevel: 'debug',
       });
-      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(true);
-      const certStatus = await getCertStatus(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'));
+      expect(fs.existsSync(path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'))).toBe(
+        true,
+      );
+      const certStatus = await getCertStatus(
+        path.join(__dirname, '..', '..', 'out', 'hellomsix_x64.msix'),
+      );
       expect(certStatus).not.toBe('NotSigned');
     });
   });

--- a/test/e2e/utils/cert.ts
+++ b/test/e2e/utils/cert.ts
@@ -8,16 +8,17 @@ const __dirname = path.dirname(__filename);
 
 export const installDevCert = async () => {
   const scriptPath = path.join(__dirname, '..', 'scripts', 'install_test_cert.ps1');
-  await powershell(scriptPath)
-}
+  await powershell(scriptPath);
+};
 
 export const getCertSubject = async (pathToFile: string) => {
-  const subject = await powershell(`(Get-AuthenticodeSignature -FilePath "${pathToFile}").SignerCertificate.Subject`);
+  const subject = await powershell(
+    `(Get-AuthenticodeSignature -FilePath "${pathToFile}").SignerCertificate.Subject`,
+  );
   return subject.replace(/^\s+|\s+$/g, '');
-}
+};
 
 export const getCertStatus = async (pathToFile: string) => {
   const status = await powershell(`(Get-AuthenticodeSignature -FilePath "${pathToFile}").Status`);
   return status.replace(/^\s+|\s+$/g, '');
-}
-
+};

--- a/test/e2e/utils/installer.ts
+++ b/test/e2e/utils/installer.ts
@@ -1,4 +1,4 @@
-import { powershell } from "../../../src/powershell";
+import { powershell } from '../../../src/powershell';
 
 export const installMSIX = async (appx: string) =>
   await powershell(`Add-AppxPackage -Path "${appx}"`);
@@ -7,22 +7,24 @@ export const uninstallMSIX = async (packageName: string) => {
   await powershell(`Get-AppxPackage -Name "${packageName}" | Remove-AppxPackage`);
 };
 
-export const checkInstall = async (name: string, version?: string) => {
-  let install = await powershell(`$p = Get-AppxPackage -Name "${name}" -ErrorAction SilentlyContinue; $p.Name + "|" + $p.Version`);
+export const checkInstall = async (name: string) => {
+  let install = await powershell(
+    `$p = Get-AppxPackage -Name "${name}" -ErrorAction SilentlyContinue; $p.Name + "|" + $p.Version`,
+  );
 
   install = install.replace(/(\r\n|\n|\r)/gm, '');
   const fields = install.split('|');
   return {
     name: fields[0],
     version: fields[1],
-  }
+  };
 };
 
 export async function readAppxManifestFromMsix(msixPath: string): Promise<string> {
   const p = msixPath.replace(/'/g, "''");
   return (
     await powershell(
-      `Add-Type -AssemblyName System.IO.Compression.FileSystem; $z = [System.IO.Compression.ZipFile]::OpenRead('${p}'); try { $e = $z.GetEntry('AppxManifest.xml'); $r = New-Object System.IO.StreamReader($e.Open()); $r.ReadToEnd() } finally { $z.Dispose() }`
+      `Add-Type -AssemblyName System.IO.Compression.FileSystem; $z = [System.IO.Compression.ZipFile]::OpenRead('${p}'); try { $e = $z.GetEntry('AppxManifest.xml'); $r = New-Object System.IO.StreamReader($e.Open()); $r.ReadToEnd() } finally { $z.Dispose() }`,
     )
   ).trim();
 }

--- a/test/e2e/vitest.config.ts
+++ b/test/e2e/vitest.config.ts
@@ -1,25 +1,17 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     name: 'e2e',
     fileParallelism: false,
     testTimeout: 20000,
-    include: [
-      'test/e2e/*.spec.ts',
-    ],
+    include: ['test/e2e/*.spec.ts'],
     coverage: {
       provider: 'istanbul',
       reporter: ['text', 'lcov'], // text for console, lcov for tooling
       reportsDirectory: './coverage',
-      include: [
-        'src/**',
-      ],
-      exclude: [
-        'src/win-version.ts',
-        'src/powershell.ts',
-        'src/logger.ts',
-      ],
-    }
+      include: ['src/**'],
+      exclude: ['src/win-version.ts', 'src/powershell.ts', 'src/logger.ts'],
+    },
   },
-})
+});

--- a/test/unit/bin.spec.ts
+++ b/test/unit/bin.spec.ts
@@ -1,9 +1,9 @@
 import { sign as windowsSign } from '@electron/windows-sign';
 import { spawn } from 'child_process';
 import { EventEmitter } from 'events';
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getCertPublisher, make, pri, priConfig, sign } from "../../src/bin";
+import { getCertPublisher, make, pri, priConfig, sign } from '../../src/bin';
 import { log } from '../../src/logger';
 
 vi.mock('child_process', () => ({
@@ -22,13 +22,13 @@ vi.mock('child_process', () => ({
     emitter.stderr = new EventEmitter();
     emitter.stdin = {
       end: vi.fn(),
-    }
+    };
     return emitter;
   }),
 }));
 
 vi.mock('@electron/windows-sign', () => ({
-    sign: vi.fn(),
+  sign: vi.fn(),
 }));
 
 vi.mock('../../src/logger');
@@ -75,7 +75,9 @@ describe('bin', () => {
       emitter.stdin = { end: vi.fn() };
       return emitter;
     });
-    await expect(getCertPublisher('C:\\cert.pfx', 'password')).rejects.toThrow('Failed running certutil Exit Code: 1 See previous errors for details');
+    await expect(getCertPublisher('C:\\cert.pfx', 'password')).rejects.toThrow(
+      'Failed running certutil Exit Code: 1 See previous errors for details',
+    );
     expect(log.error).toHaveBeenCalledWith('stderr of certutil', false, ['certutil: Error: oops']);
   });
 
@@ -93,7 +95,9 @@ describe('bin', () => {
       emitter.stdin = { end: vi.fn() };
       return emitter;
     });
-    await expect(getCertPublisher('C:\\cert.pfx', 'password')).rejects.toThrow('Failed running certutil Exit Code: 1 See previous errors for details');
+    await expect(getCertPublisher('C:\\cert.pfx', 'password')).rejects.toThrow(
+      'Failed running certutil Exit Code: 1 See previous errors for details',
+    );
     expect(log.error).toHaveBeenCalledWith('stdout of certutil', false, ['some stdout output', '']);
   });
 
@@ -111,8 +115,14 @@ describe('bin', () => {
       emitter.stdin = { end: vi.fn() };
       return emitter;
     });
-    await expect(getCertPublisher('C:\\cert.pfx', 'password')).rejects.toThrow('Failed running certutil Exit Code: 1 See previous errors for details');
-    expect(log.error).not.toHaveBeenCalledWith('stderr of certutil', expect.anything(), expect.anything());
+    await expect(getCertPublisher('C:\\cert.pfx', 'password')).rejects.toThrow(
+      'Failed running certutil Exit Code: 1 See previous errors for details',
+    );
+    expect(log.error).not.toHaveBeenCalledWith(
+      'stderr of certutil',
+      expect.anything(),
+      expect.anything(),
+    );
     expect(log.error).toHaveBeenCalledWith('stdout of certutil', false, ['stdout only', '']);
   });
 
@@ -133,12 +143,16 @@ describe('bin', () => {
   });
 
   it('should call priConfig with the correct arguments', async () => {
-   await priConfig({
+    await priConfig({
       makePri: 'C:\\makepri.exe',
       priConfig: 'C:\\priConfig.xml',
       createPri: true,
     } as any);
-    expect(spawn).toHaveBeenCalledWith('C:\\makepri.exe', ['createconfig', '/cf', 'C:\\priConfig.xml', '/dq', 'en-US'], {});
+    expect(spawn).toHaveBeenCalledWith(
+      'C:\\makepri.exe',
+      ['createconfig', '/cf', 'C:\\priConfig.xml', '/dq', 'en-US'],
+      {},
+    );
   });
 
   it('should call priConfig with the correct arguments', async () => {
@@ -159,7 +173,22 @@ describe('bin', () => {
       appManifestLayout: 'C:\\appManifestLayout.xml',
       createPri: true,
     } as any);
-    expect(spawn).toHaveBeenCalledWith('C:\\makepri.exe', ['new', '/pr', 'C:\\layoutDir', '/cf', 'C:\\priConfig.xml', '/mn', 'C:\\appManifestLayout.xml', '/of', 'C:\\priFile.xml', '/v'], {});
+    expect(spawn).toHaveBeenCalledWith(
+      'C:\\makepri.exe',
+      [
+        'new',
+        '/pr',
+        'C:\\layoutDir',
+        '/cf',
+        'C:\\priConfig.xml',
+        '/mn',
+        'C:\\appManifestLayout.xml',
+        '/of',
+        'C:\\priFile.xml',
+        '/v',
+      ],
+      {},
+    );
   });
 
   it('should skip pri if createPri is false', async () => {
@@ -177,7 +206,11 @@ describe('bin', () => {
       isSparsePackage: false,
       compress: true,
     } as any);
-    expect(spawn).toHaveBeenCalledWith('C:\\makeappx.exe', ['pack', '/d', 'C:\\layoutDir', '/p', 'C:\\msix', '/o'], {});
+    expect(spawn).toHaveBeenCalledWith(
+      'C:\\makeappx.exe',
+      ['pack', '/d', 'C:\\layoutDir', '/p', 'C:\\msix', '/o'],
+      {},
+    );
   });
 
   it('should call make with the correct arguments for a sparse package', async () => {
@@ -188,7 +221,11 @@ describe('bin', () => {
       isSparsePackage: true,
       compress: true,
     } as any);
-    expect(spawn).toHaveBeenCalledWith('C:\\makeappx.exe', ['pack', '/d', 'C:\\layoutDir', '/p', 'C:\\msix', '/o', '/nv'], {});
+    expect(spawn).toHaveBeenCalledWith(
+      'C:\\makeappx.exe',
+      ['pack', '/d', 'C:\\layoutDir', '/p', 'C:\\msix', '/o', '/nv'],
+      {},
+    );
   });
 
   it('should call make with the correct arguments for an uncompressed package', async () => {
@@ -199,11 +236,15 @@ describe('bin', () => {
       isSparsePackage: false,
       compress: false,
     } as any);
-    expect(spawn).toHaveBeenCalledWith('C:\\makeappx.exe', ['pack', '/d', 'C:\\layoutDir', '/p', 'C:\\msix', '/o', '/nc'], {});
+    expect(spawn).toHaveBeenCalledWith(
+      'C:\\makeappx.exe',
+      ['pack', '/d', 'C:\\layoutDir', '/p', 'C:\\msix', '/o', '/nc'],
+      {},
+    );
   });
 
   it('should call sign with the correct arguments', async () => {
-    sign({
+    await sign({
       sign: true,
       signTool: 'C:\\SignTool.exe',
       signParams: ['-fd', 'sha256', '-f', 'C:\\cert.pfx'],
@@ -225,7 +266,7 @@ describe('bin', () => {
   });
 
   it('should not call sign if sign is false', async () => {
-    sign({
+    await sign({
       sign: false,
       signTool: 'C:\\SignTool.exe',
       signParams: ['-fd', 'sha256', '-f', 'C:\\cert.pfx'],

--- a/test/unit/cert.spec.ts
+++ b/test/unit/cert.spec.ts
@@ -1,18 +1,17 @@
 import fs from 'fs-extra';
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ensureDevCert } from "../../src/cert";
+import { ensureDevCert } from '../../src/cert';
 import { powershell } from '../../src/powershell';
 
 vi.mock('fs-extra', async (importOriginal) => {
-  const actual = await importOriginal() as Record < string,
-    any > ;
+  const actual = (await importOriginal()) as Record<string, any>;
   return {
     default: {
-    readFileSync: actual.readFileSync,
+      readFileSync: actual.readFileSync,
       writeFileSync: vi.fn(),
       unlinkSync: vi.fn(),
-    }
+    },
   };
 });
 
@@ -27,7 +26,7 @@ const programOptions = {
   cert_pass: 'my_password',
   cert_pfx: 'C:\\out\\dev_cert.pfx',
   cert_cer: 'C:\\out\\dev_cert.cer',
-}
+};
 
 describe('cert', () => {
   beforeEach(() => {
@@ -37,7 +36,7 @@ describe('cert', () => {
   it('should not call powershell if createDevCert is false', async () => {
     const programOptions = {
       createDevCert: false,
-    }
+    };
     await ensureDevCert(programOptions as any);
     expect(powershell).not.toHaveBeenCalled();
     expect(fs.writeFileSync).not.toHaveBeenCalled();
@@ -57,7 +56,10 @@ describe('cert', () => {
   it('should call powershell to create a dev cert', async () => {
     await ensureDevCert(programOptions as any);
     expect(powershell).toHaveBeenCalledWith('C:\\out\\create_dev_cert.ps1');
-    expect(fs.writeFileSync).toHaveBeenCalledWith('C:\\out\\create_dev_cert.ps1', expect.any(String));
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      'C:\\out\\create_dev_cert.ps1',
+      expect.any(String),
+    );
     expect(fs.unlinkSync).toHaveBeenCalledWith('C:\\out\\create_dev_cert.ps1');
   });
 });

--- a/test/unit/manifestation.spec.ts
+++ b/test/unit/manifestation.spec.ts
@@ -1,23 +1,28 @@
-import * as path from 'path'
-import { expect, describe, it, vi } from 'vitest'
+import * as path from 'path';
+import { expect, describe, it, vi } from 'vitest';
 
 import { makeProgramOptions } from '../../src/utils';
 import { ManifestGenerationVariables, PackagingOptions } from '../../src/types';
-import { getManifestVariables, manifest, normalizeToastActivatorClsid } from '../../src/manifestation';
+import {
+  getManifestVariables,
+  manifest,
+  normalizeToastActivatorClsid,
+} from '../../src/manifestation';
 
 vi.mock('fs-extra', async (importOriginal) => {
-  const actual = await importOriginal() as Record < string,
-    any > ;
-  return { default:  {
-    exists: vi.fn().mockReturnValue(true),
-    emptyDir: vi.fn(),
-    ensureDir: vi.fn(),
-    pathExists: vi.fn().mockReturnValue(true),
-    readFileSync: actual.readFileSync,
-    readFile: actual.readFile,
-    writeFile: vi.fn(),
-    copy: vi.fn(),
-  }};
+  const actual = (await importOriginal()) as Record<string, any>;
+  return {
+    default: {
+      exists: vi.fn().mockReturnValue(true),
+      emptyDir: vi.fn(),
+      ensureDir: vi.fn(),
+      pathExists: vi.fn().mockReturnValue(true),
+      readFileSync: actual.readFileSync,
+      readFile: actual.readFile,
+      writeFile: vi.fn(),
+      copy: vi.fn(),
+    },
+  };
 });
 
 const minimalManifestVariables: ManifestGenerationVariables = {
@@ -26,24 +31,23 @@ const minimalManifestVariables: ManifestGenerationVariables = {
   packageIdentity: 'com.electron.myapp',
   packageVersion: '1.42.0.0',
   publisher: 'Jan Hannemann',
-}
+};
 
 const minimalPackagingOptions: PackagingOptions = {
   appDir: 'C:\\app',
   outputDir: 'C:\\out',
   packageAssets: 'C:\\assets',
   manifestVariables: minimalManifestVariables,
-}
+};
 
 describe('manifestation', () => {
   describe('getManifestVariables', () => {
-
     it('should read manifest variables from AppxManifest.xml correctly', async () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
         appManifest: path.join(__dirname, 'fixtures', 'AppxManifest_x64.xml'),
-      }
-      const manifestVars = await getManifestVariables(packagingOptions)
+      };
+      const manifestVars = await getManifestVariables(packagingOptions);
       expect(manifestVars).toBeDefined();
       expect(manifestVars.manifestAppName).toBe('hellomsix');
       expect(manifestVars.manifestPackageArch).toBe('x64');
@@ -56,17 +60,16 @@ describe('manifestation', () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
         appManifest: path.join(__dirname, 'fixtures', 'AppxManifest_Sparse.xml'),
-      }
-      const manifestVars = await getManifestVariables(packagingOptions)
+      };
+      const manifestVars = await getManifestVariables(packagingOptions);
       expect(manifestVars.manifestIsSparsePackage).toBe(true);
-
     });
 
     it('should return null if no manifest is provided', async () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
-      }
-      const manifestVars = await getManifestVariables(packagingOptions)
+      };
+      const manifestVars = await getManifestVariables(packagingOptions);
       expect(manifestVars).toBeNull();
     });
 
@@ -74,8 +77,8 @@ describe('manifestation', () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
         appManifest: path.join(__dirname, 'fixtures', 'AppxManifest_invalid.xml'),
-      }
-      const manifestVars = await getManifestVariables(packagingOptions)
+      };
+      const manifestVars = await getManifestVariables(packagingOptions);
       expect(manifestVars).toBeDefined();
       expect(manifestVars.manifestAppName).toBeUndefined();
       expect(manifestVars.manifestPackageArch).toBeUndefined();
@@ -90,7 +93,7 @@ describe('manifestation', () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
         appManifest: path.join(__dirname, 'fixtures', 'AppxManifest_x64.xml'),
-      }
+      };
       const appManifestIn = await manifest(packagingOptions);
       expect(appManifestIn).toMatch(/<Identity Name="Electron.MySuite.HelloMSIX"/);
       expect(appManifestIn).toMatch(/ProcessorArchitecture="x64"/);
@@ -101,9 +104,8 @@ describe('manifestation', () => {
       expect(appManifestIn).toMatch(/<Logo>assets\\icon.png<\/Logo>/);
     });
 
-
     it('should generate a valid manifest with minimal arguments', async () => {
-      const {appManifestIn} = await makeProgramOptions(minimalPackagingOptions, null as any);
+      const { appManifestIn } = await makeProgramOptions(minimalPackagingOptions, null as any);
       expect(appManifestIn).toMatch(/<Identity Name="com.electron.myapp"/);
       expect(appManifestIn).toMatch(/ProcessorArchitecture="x64"/);
       expect(appManifestIn).toMatch(/Version="1.42.0.0"/);
@@ -111,8 +113,12 @@ describe('manifestation', () => {
       expect(appManifestIn).toMatch(/<DisplayName>HelloMSIX<\/DisplayName>/);
       expect(appManifestIn).toMatch(/<PublisherDisplayName>Jan Hannemann<\/PublisherDisplayName>/);
       expect(appManifestIn).toMatch(/<Logo>assets\\icon.png<\/Logo>/);
-      expect(appManifestIn).toMatch(/<TargetDeviceFamily Name="Windows\.Desktop" MinVersion="[\d.]+" MaxVersionTested="[\d.]+" \/>/);
-      expect(appManifestIn).toMatch(/<Application Id="App"  Executable="app\\HelloMSIX.exe" EntryPoint="Windows.FullTrustApplication">/);
+      expect(appManifestIn).toMatch(
+        /<TargetDeviceFamily Name="Windows\.Desktop" MinVersion="[\d.]+" MaxVersionTested="[\d.]+" \/>/,
+      );
+      expect(appManifestIn).toMatch(
+        /<Application Id="App"  Executable="app\\HelloMSIX.exe" EntryPoint="Windows.FullTrustApplication">/,
+      );
       expect(appManifestIn).toMatch(/DisplayName="HelloMSIX"/);
       expect(appManifestIn).toMatch(/Description="HelloMSIX"/);
       expect(appManifestIn).toMatch(/Square44x44Logo="assets\\Square44x44Logo.png"/);
@@ -133,11 +139,15 @@ describe('manifestation', () => {
           packageMinOSVersion: '10.0.17763.0',
           packageMaxOSVersionTested: '10.0.17763.0',
         },
-      }
+      };
       const appManifestIn = await manifest(packagingOptions);
       expect(appManifestIn).toMatch(/<DisplayName>Custom Package Display Name<\/DisplayName>/);
-      expect(appManifestIn).toMatch(/<PublisherDisplayName>Custom Publisher Display Name<\/PublisherDisplayName>/);
-      expect(appManifestIn).toMatch(/<TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.17763.0" \/>/);
+      expect(appManifestIn).toMatch(
+        /<PublisherDisplayName>Custom Publisher Display Name<\/PublisherDisplayName>/,
+      );
+      expect(appManifestIn).toMatch(
+        /<TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.17763.0" \/>/,
+      );
       expect(appManifestIn).toMatch(/DisplayName="Custom Display Name"/);
       expect(appManifestIn).toMatch(/Description="Custom Package Description"/);
       expect(appManifestIn).toMatch(/BackgroundColor="Custom Background Color"/);
@@ -151,9 +161,11 @@ describe('manifestation', () => {
           appDisplayName: 'Custom Display Name',
           packageMinOSVersion: '10.0.17763.0',
         },
-      }
+      };
       const appManifestIn = await manifest(packagingOptions);
-      expect(appManifestIn).toMatch(/<TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.17763.0" \/>/);
+      expect(appManifestIn).toMatch(
+        /<TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.17763.0" \/>/,
+      );
     });
 
     it('should use packageDisplayName as display name if appDisplayName and packageDescription is not provided', async () => {
@@ -163,7 +175,7 @@ describe('manifestation', () => {
           ...minimalManifestVariables,
           packageDisplayName: 'Custom Package Display Name',
         },
-      }
+      };
       const appManifestIn = await manifest(packagingOptions);
       expect(appManifestIn).toMatch(/<DisplayName>Custom Package Display Name<\/DisplayName>/);
       expect(appManifestIn).toMatch(/DisplayName="Custom Package Display Name"/);
@@ -177,7 +189,7 @@ describe('manifestation', () => {
           ...minimalManifestVariables,
           appDisplayName: 'Custom App Display Name',
         },
-      }
+      };
       const appManifestIn = await manifest(packagingOptions);
       expect(appManifestIn).toMatch(/Description="Custom App Display Name"/);
     });
@@ -186,7 +198,7 @@ describe('manifestation', () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
         manifestVariables: undefined,
-      }
+      };
       const appManifestIn = await manifest(packagingOptions);
       expect(appManifestIn).toBeNull();
     });
@@ -205,17 +217,15 @@ describe('manifestation', () => {
       };
       const appManifestIn = await manifest(packagingOptions);
       expect(appManifestIn).toContain(
-        'xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"'
+        'xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"',
       );
       expect(appManifestIn).toMatch(/IgnorableNamespaces="[^"]*\bcom\b/);
       expect(appManifestIn).toMatch(
-        /<com:Extension Category="windows\.comServer">[\s\S]*<com:ExeServer Executable="app\\HelloMSIX\.exe" Arguments="-ToastActivated">/
+        /<com:Extension Category="windows\.comServer">[\s\S]*<com:ExeServer Executable="app\\HelloMSIX\.exe" Arguments="-ToastActivated">/,
       );
+      expect(appManifestIn).toContain('<com:Class Id="a1b2c3d4-e5f6-7890-abcd-ef1234567890"/>');
       expect(appManifestIn).toContain(
-        '<com:Class Id="a1b2c3d4-e5f6-7890-abcd-ef1234567890"/>'
-      );
-      expect(appManifestIn).toContain(
-        '<desktop:ToastNotificationActivation ToastActivatorCLSID="a1b2c3d4-e5f6-7890-abcd-ef1234567890" />'
+        '<desktop:ToastNotificationActivation ToastActivatorCLSID="a1b2c3d4-e5f6-7890-abcd-ef1234567890" />',
       );
     });
 
@@ -231,11 +241,9 @@ describe('manifestation', () => {
       };
       const appManifestIn = await manifest(packagingOptions);
       expect(appManifestIn).toMatch(
-        /<com:ExeServer Executable="app\\HelloMSIX\.exe" Arguments="-ToastActivated">/
+        /<com:ExeServer Executable="app\\HelloMSIX\.exe" Arguments="-ToastActivated">/,
       );
-      expect(appManifestIn).toContain(
-        '<com:Class Id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"/>'
-      );
+      expect(appManifestIn).toContain('<com:Class Id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"/>');
     });
 
     it('should escape XML in comToastActivation executable basename', async () => {
@@ -250,9 +258,7 @@ describe('manifestation', () => {
         },
       };
       const appManifestIn = await manifest(packagingOptions);
-      expect(appManifestIn).toContain(
-        'Executable="app\\my&amp;app&quot;test&apos;exe.exe"'
-      );
+      expect(appManifestIn).toContain('Executable="app\\my&amp;app&quot;test&apos;exe.exe"');
     });
 
     it('should escape XML in comToastActivation arguments', async () => {
@@ -289,10 +295,10 @@ describe('manifestation', () => {
   describe('normalizeToastActivatorClsid', () => {
     it('normalizes GUID with or without braces to lowercase braced form', () => {
       expect(normalizeToastActivatorClsid('{ABCDEF01-2345-6789-ABCD-EF0123456789}')).toBe(
-        '{abcdef01-2345-6789-abcd-ef0123456789}'
+        '{abcdef01-2345-6789-abcd-ef0123456789}',
       );
       expect(normalizeToastActivatorClsid('ABCDEF01-2345-6789-ABCD-EF0123456789')).toBe(
-        '{abcdef01-2345-6789-abcd-ef0123456789}'
+        '{abcdef01-2345-6789-abcd-ef0123456789}',
       );
     });
   });

--- a/test/unit/powershell.spec.ts
+++ b/test/unit/powershell.spec.ts
@@ -1,29 +1,46 @@
-import { spawn } from "@malept/cross-spawn-promise";
-import { describe, expect, it, vi } from "vitest";
+import { spawn } from '@malept/cross-spawn-promise';
+import { describe, expect, it, vi } from 'vitest';
 
-import { powershell } from "../../src/powershell";
+import { powershell } from '../../src/powershell';
 
-vi.mock(import("@malept/cross-spawn-promise"), async () => {
+vi.mock(import('@malept/cross-spawn-promise'), async () => {
   return {
     spawn: vi.fn(),
-  }
-})
+  };
+});
 
 describe('powershell', () => {
   it('should call powershell', async () => {
     await powershell('C:\\out\\create_dev_cert.ps1');
-    expect(spawn).toHaveBeenCalledWith('pwsh.exe', ['-NoProfile', '-ExecutionPolicy', 'Bypass', 'C:\\out\\create_dev_cert.ps1']);
+    expect(spawn).toHaveBeenCalledWith('pwsh.exe', [
+      '-NoProfile',
+      '-ExecutionPolicy',
+      'Bypass',
+      'C:\\out\\create_dev_cert.ps1',
+    ]);
   });
 
   it('should call powershell', async () => {
     await powershell('Get-Process');
-    expect(spawn).toHaveBeenCalledWith('pwsh.exe', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', 'Get-Process']);
+    expect(spawn).toHaveBeenCalledWith('pwsh.exe', [
+      '-NoProfile',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-Command',
+      'Get-Process',
+    ]);
   });
 
   it('should call powershell', async () => {
-    vi.mocked(spawn).mockResolvedValue({toString: () => 'Hello'} as any);
+    vi.mocked(spawn).mockResolvedValue({ toString: () => 'Hello' } as any);
     const result = await powershell('Get-Process');
     expect(result).toBe('Hello');
-    expect(spawn).toHaveBeenCalledWith('pwsh.exe', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', 'Get-Process']);
+    expect(spawn).toHaveBeenCalledWith('pwsh.exe', [
+      '-NoProfile',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-Command',
+      'Get-Process',
+    ]);
   });
 });

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -1,23 +1,10 @@
-import fs from 'fs-extra'
+import fs from 'fs-extra';
 import path from 'path';
-import {
-  expect,
-  describe,
-  it,
-  vi,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll
-} from 'vitest'
+import { expect, describe, it, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
 
 import { log } from '../../src/logger';
 import { getCertPublisher } from '../../src/bin';
-import {
-  ManifestVariables,
-  PackagingOptions,
-  ProgramOptions
-} from '../../src/types';
+import { ManifestVariables, PackagingOptions, ProgramOptions } from '../../src/types';
 import {
   removeFileExtension,
   removePublisherPrefix,
@@ -27,23 +14,23 @@ import {
   setLogLevel,
   makeProgramOptions,
   createLayout,
-  getBinaries
+  getBinaries,
 } from '../../src/utils';
 import { SignOptions } from '@electron/windows-sign';
 
 let originalProcessorArchitecture = process.env.PROCESSOR_ARCHITECTURE;
 const overrideProcessorArchitecture = (arch: string) => {
   process.env.PROCESSOR_ARCHITECTURE = arch;
-}
+};
 const restoreProcessorArchitecture = () => {
   process.env.PROCESSOR_ARCHITECTURE = originalProcessorArchitecture;
-}
+};
 
 const incompletePackagingOptions: PackagingOptions = {
   appDir: 'C:\\app',
   outputDir: 'C:\\out',
   sign: true,
-}
+};
 
 const minimalPackagingOptions: PackagingOptions = {
   appDir: 'C:\\app',
@@ -55,13 +42,12 @@ const minimalPackagingOptions: PackagingOptions = {
     appExecutable: 'app.exe',
     targetArch: 'x64',
   },
-}
+};
 
 vi.mock('../../src/logger');
 vi.mock('../../src/bin');
 vi.mock('fs-extra', async (importOriginal) => {
-  const actual = await importOriginal() as Record < string,
-    any > ;
+  const actual = (await importOriginal()) as Record<string, any>;
   return {
     default: {
       exists: vi.fn().mockReturnValue(true),
@@ -72,10 +58,9 @@ vi.mock('fs-extra', async (importOriginal) => {
       readFile: actual.readFile,
       writeFile: vi.fn(),
       copy: vi.fn(),
-    }
+    },
   };
 });
-
 
 describe('utils', () => {
   beforeAll(() => {
@@ -92,19 +77,33 @@ describe('utils', () => {
     it('should return the binaries', async () => {
       const binaries = await getBinaries('C:\\Program Files (x86)\\Windows Kits\\10\\bin');
       expect(binaries).toBeDefined();
-      expect(binaries.makeAppx).toBe('C:\\Program Files (x86)\\Windows Kits\\10\\bin\\makeappx.exe');
+      expect(binaries.makeAppx).toBe(
+        'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\makeappx.exe',
+      );
       expect(binaries.makePri).toBe('C:\\Program Files (x86)\\Windows Kits\\10\\bin\\makepri.exe');
-      expect(binaries.signTool).toBe('C:\\Program Files (x86)\\Windows Kits\\10\\bin\\SignTool.exe');
-      expect(binaries.makeCert).toBe('C:\\Program Files (x86)\\Windows Kits\\10\\bin\\makecert.exe');
+      expect(binaries.signTool).toBe(
+        'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\SignTool.exe',
+      );
+      expect(binaries.makeCert).toBe(
+        'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\makecert.exe',
+      );
     });
 
     it('should throw an error if the binaries are not found', async () => {
       vi.mocked(fs.exists).mockResolvedValue(false as any);
       await getBinaries('C:\\Program Files (x86)\\Windows Kits\\10\\bin');
-      expect(log.error).toHaveBeenCalledWith('MakeAppx binary makeappx.exe not found in:', true, { windowsKitPath: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin' });
-      expect(log.error).toHaveBeenCalledWith('MakePri binary makepri.exe not found in:', true, { windowsKitPath: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin' });
-      expect(log.error).toHaveBeenCalledWith('SignTool binary SignTool.exe not found in:', true, { windowsKitPath: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin' });
-      expect(log.error).toHaveBeenCalledWith('MakeCert binary makecert.exe not found in:', true, { windowsKitPath: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin' });
+      expect(log.error).toHaveBeenCalledWith('MakeAppx binary makeappx.exe not found in:', true, {
+        windowsKitPath: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin',
+      });
+      expect(log.error).toHaveBeenCalledWith('MakePri binary makepri.exe not found in:', true, {
+        windowsKitPath: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin',
+      });
+      expect(log.error).toHaveBeenCalledWith('SignTool binary SignTool.exe not found in:', true, {
+        windowsKitPath: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin',
+      });
+      expect(log.error).toHaveBeenCalledWith('MakeCert binary makecert.exe not found in:', true, {
+        windowsKitPath: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin',
+      });
     });
   });
 
@@ -140,10 +139,7 @@ describe('utils', () => {
 
     it('should empty output dir if it exists', async () => {
       vi.mocked(fs.exists).mockResolvedValue(true as any);
-      const {
-        outputDir,
-        layoutDir
-      } = await ensureFolders(minimalPackagingOptions);
+      const { outputDir, layoutDir } = await ensureFolders(minimalPackagingOptions);
       expect(fs.emptyDir).toHaveBeenCalledWith('C:\\out');
 
       expect(fs.ensureDir).toHaveBeenCalledTimes(1);
@@ -155,10 +151,7 @@ describe('utils', () => {
 
     it('should create output dir if it does not exist', async () => {
       vi.mocked(fs.exists).mockResolvedValue(false as any);
-      const {
-        outputDir,
-        layoutDir
-      } = await ensureFolders(minimalPackagingOptions);
+      const { outputDir, layoutDir } = await ensureFolders(minimalPackagingOptions);
 
       expect(fs.emptyDir).toHaveBeenCalledTimes(0);
       expect(fs.ensureDir).toHaveBeenCalledTimes(2);
@@ -183,18 +176,24 @@ describe('utils', () => {
       it('should throw an error if no app manifest nor manifest variables are provided', async () => {
         const packagingOptions: PackagingOptions = {
           ...incompletePackagingOptions,
-        }
+        };
         await verifyOptions(packagingOptions);
-        expect(log.error).toHaveBeenCalledWith('Neither app manifest <appManifest> nor manifest variables <manifestVariables> provided.', true);
+        expect(log.error).toHaveBeenCalledWith(
+          'Neither app manifest <appManifest> nor manifest variables <manifestVariables> provided.',
+          true,
+        );
       });
 
       it('should throw an error if no package version is provided', async () => {
         const packagingOptions: PackagingOptions = {
           ...incompletePackagingOptions,
-          manifestVariables: { } as any
-        }
+          manifestVariables: {} as any,
+        };
         await verifyOptions(packagingOptions);
-        expect(log.error).toHaveBeenCalledWith('Neither package version <packageVersion> nor app manifest <appManifest> provided.', true);
+        expect(log.error).toHaveBeenCalledWith(
+          'Neither package version <packageVersion> nor app manifest <appManifest> provided.',
+          true,
+        );
       });
 
       it('should throw an error if package version is not a valid version', async () => {
@@ -202,10 +201,14 @@ describe('utils', () => {
           ...incompletePackagingOptions,
           manifestVariables: {
             packageVersion: 'not a version',
-          } as any
-        }
+          } as any,
+        };
         await verifyOptions(packagingOptions);
-        expect(log.error).toHaveBeenCalledWith('Package version <packageVersion> is not a semantic version.', true, { packageVersion: 'not a version' });
+        expect(log.error).toHaveBeenCalledWith(
+          'Package version <packageVersion> is not a semantic version.',
+          true,
+          { packageVersion: 'not a version' },
+        );
       });
 
       it('should throw an error if no publisher is provided', async () => {
@@ -213,10 +216,13 @@ describe('utils', () => {
           ...incompletePackagingOptions,
           manifestVariables: {
             packageVersion: '1.0.0',
-          } as any
-        }
+          } as any,
+        };
         await verifyOptions(packagingOptions);
-        expect(log.error).toHaveBeenCalledWith('Neither publisher <publisher> nor app manifest <appManifest> provided.', true);
+        expect(log.error).toHaveBeenCalledWith(
+          'Neither publisher <publisher> nor app manifest <appManifest> provided.',
+          true,
+        );
       });
 
       it('should throw an error if no app executable is provided', async () => {
@@ -225,10 +231,13 @@ describe('utils', () => {
           manifestVariables: {
             packageVersion: '1.0.0',
             publisher: 'Electron',
-          } as any
-        }
+          } as any,
+        };
         await verifyOptions(packagingOptions);
-        expect(log.error).toHaveBeenCalledWith('Neither app executable <appExecutable> nor app manifest <appManifest> provided.', true);
+        expect(log.error).toHaveBeenCalledWith(
+          'Neither app executable <appExecutable> nor app manifest <appManifest> provided.',
+          true,
+        );
       });
 
       it('should throw an error if no target architecture is provided', async () => {
@@ -238,10 +247,13 @@ describe('utils', () => {
             packageVersion: '1.0.0',
             publisher: 'Electron',
             appExecutable: 'C:\\app\\app.exe',
-          } as any
-        }
+          } as any,
+        };
         await verifyOptions(packagingOptions);
-        expect(log.error).toHaveBeenCalledWith('Neither target architecture <targetArch> nor app manifest <appManifest> provided.', true);
+        expect(log.error).toHaveBeenCalledWith(
+          'Neither target architecture <targetArch> nor app manifest <appManifest> provided.',
+          true,
+        );
       });
 
       it('should throw an error if no package identity is provided', async () => {
@@ -252,10 +264,13 @@ describe('utils', () => {
             publisher: 'Electron',
             appExecutable: 'C:\\app\\app.exe',
             targetArch: 'x64',
-          } as any
-        }
+          } as any,
+        };
         await verifyOptions(packagingOptions);
-        expect(log.error).toHaveBeenCalledWith('Neither package identity <packageIdentity> nor app manifest <appManifest> provided.', true);
+        expect(log.error).toHaveBeenCalledWith(
+          'Neither package identity <packageIdentity> nor app manifest <appManifest> provided.',
+          true,
+        );
       });
 
       it('should throw an error if comToastActivation CLSID is invalid', async () => {
@@ -268,10 +283,14 @@ describe('utils', () => {
             targetArch: 'x64',
             packageIdentity: 'com.app',
             comToastActivation: { toastActivatorClsid: 'not-a-guid' },
-          } as any
-        }
+          } as any,
+        };
         await verifyOptions(packagingOptions);
-        expect(log.error).toHaveBeenCalledWith('comToastActivation.toastActivatorClsid must be a valid GUID.', true, { toastActivatorClsid: 'not-a-guid' });
+        expect(log.error).toHaveBeenCalledWith(
+          'comToastActivation.toastActivatorClsid must be a valid GUID.',
+          true,
+          { toastActivatorClsid: 'not-a-guid' },
+        );
       });
 
       it('should not error when comToastActivation CLSID is valid', async () => {
@@ -294,7 +313,7 @@ describe('utils', () => {
         expect(log.error).not.toHaveBeenCalledWith(
           'comToastActivation.toastActivatorClsid must be a valid GUID.',
           true,
-          expect.anything()
+          expect.anything(),
         );
       });
 
@@ -307,11 +326,13 @@ describe('utils', () => {
             appExecutable: 'C:\\app\\app.exe',
             targetArch: 'x64',
             packageIdentity: 'Electron.App',
-          } as any
-        }
+          } as any,
+        };
         vi.mocked(fs.exists).mockResolvedValue(true as any);
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Neither publisher display name <publisherDisplayName> nor app manifest <appManifest> provided. Using publisher as display name.');
+        expect(log.warn).toHaveBeenCalledWith(
+          'Neither publisher display name <publisherDisplayName> nor app manifest <appManifest> provided. Using publisher as display name.',
+        );
       });
 
       it('should warn if no package display name is provided', async () => {
@@ -324,11 +345,13 @@ describe('utils', () => {
             targetArch: 'x64',
             packageIdentity: 'Electron.App',
             publisherDisplayName: 'Electron',
-          } as any
-        }
+          } as any,
+        };
         vi.mocked(fs.exists).mockResolvedValue(true as any);
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Neither package display name <packageDisplayName> nor app manifest <appManifest> provided. Using app executable as display name.');
+        expect(log.warn).toHaveBeenCalledWith(
+          'Neither package display name <packageDisplayName> nor app manifest <appManifest> provided. Using app executable as display name.',
+        );
       });
 
       it('should warn if no packageMinOSVersion is provided', async () => {
@@ -341,11 +364,13 @@ describe('utils', () => {
             targetArch: 'x64',
             packageIdentity: 'Electron.App',
             publisherDisplayName: 'Electron',
-          } as any
-        }
+          } as any,
+        };
         vi.mocked(fs.exists).mockResolvedValue(true as any);
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Neither package min OS version <packageMinOSVersion> nor app manifest <appManifest> provided. Using default OS version 10.0.19041.0.');
+        expect(log.warn).toHaveBeenCalledWith(
+          'Neither package min OS version <packageMinOSVersion> nor app manifest <appManifest> provided. Using default OS version 10.0.19041.0.',
+        );
       });
 
       it('should warn if no packageMaxOSVersionTested is provided', async () => {
@@ -359,11 +384,13 @@ describe('utils', () => {
             packageIdentity: 'Electron.App',
             publisherDisplayName: 'Electron',
             packageMinOSVersion: '10.0.19041.0',
-          } as any
-        }
+          } as any,
+        };
         vi.mocked(fs.exists).mockResolvedValue(true as any);
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Neither package max OS version tested <packageMaxOSVersionTested> nor app manifest <appManifest> provided. Using default OS version 10.0.19041.0.');
+        expect(log.warn).toHaveBeenCalledWith(
+          'Neither package max OS version tested <packageMaxOSVersionTested> nor app manifest <appManifest> provided. Using default OS version 10.0.19041.0.',
+        );
       });
 
       it('should warn if no appDisplayName is provided', async () => {
@@ -378,11 +405,13 @@ describe('utils', () => {
             publisherDisplayName: 'Electron',
             packageMinOSVersion: '10.0.19041.0',
             packageMaxOSVersionTested: '10.0.19041.0',
-          } as any
-        }
+          } as any,
+        };
         vi.mocked(fs.exists).mockResolvedValue(true as any);
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Neither app display name <appDisplayName> nor app manifest <appManifest> provided. Using app executable as display name.');
+        expect(log.warn).toHaveBeenCalledWith(
+          'Neither app display name <appDisplayName> nor app manifest <appManifest> provided. Using app executable as display name.',
+        );
       });
 
       it('should warn if no packageDescription is provided', async () => {
@@ -398,11 +427,13 @@ describe('utils', () => {
             packageMinOSVersion: '10.0.19041.0',
             packageMaxOSVersionTested: '10.0.19041.0',
             appDisplayName: 'Electron',
-          } as any
-        }
+          } as any,
+        };
         vi.mocked(fs.exists).mockResolvedValue(true as any);
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Neither package description <packageDescription> nor app manifest <appManifest> provided. Using app executable as description.');
+        expect(log.warn).toHaveBeenCalledWith(
+          'Neither package description <packageDescription> nor app manifest <appManifest> provided. Using app executable as description.',
+        );
       });
 
       it('should warn if no packageBackgroundColor is provided', async () => {
@@ -419,11 +450,13 @@ describe('utils', () => {
             packageMaxOSVersionTested: '10.0.19041.0',
             appDisplayName: 'Electron',
             packageDescription: 'Electron',
-          } as any
-        }
+          } as any,
+        };
         vi.mocked(fs.exists).mockResolvedValue(true as any);
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Neither package background color <packageBackgroundColor> nor app manifest <appManifest> provided. Using default background color transparent.');
+        expect(log.warn).toHaveBeenCalledWith(
+          'Neither package background color <packageBackgroundColor> nor app manifest <appManifest> provided. Using default background color transparent.',
+        );
       });
     });
 
@@ -431,9 +464,11 @@ describe('utils', () => {
       it('it should warn if no app dir or files are provided in because of windows sign options being undefined', async () => {
         const packagingOptions: PackagingOptions = {
           ...minimalPackagingOptions,
-        }
+        };
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Neither path to application <appDir> nor files <files> provided in windows sign options. Will add MSIX package to files.');
+        expect(log.warn).toHaveBeenCalledWith(
+          'Neither path to application <appDir> nor files <files> provided in windows sign options. Will add MSIX package to files.',
+        );
       });
 
       it('it should warn if no app dir or files are provided in windows sign options', async () => {
@@ -443,9 +478,11 @@ describe('utils', () => {
             certificateFile: 'C:\\cert.pfx',
             certificatePassword: '123456',
           } as any,
-        }
+        };
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Neither path to application <appDir> nor files <files> provided in windows sign options. Will add MSIX package to files.');
+        expect(log.warn).toHaveBeenCalledWith(
+          'Neither path to application <appDir> nor files <files> provided in windows sign options. Will add MSIX package to files.',
+        );
       });
 
       it('it should warn if  app dir or files are undefined in windows sign options', async () => {
@@ -457,9 +494,11 @@ describe('utils', () => {
             appDirectory: undefined,
             files: undefined,
           } as any,
-        }
+        };
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Neither path to application <appDir> nor files <files> provided in windows sign options. Will add MSIX package to files.');
+        expect(log.warn).toHaveBeenCalledWith(
+          'Neither path to application <appDir> nor files <files> provided in windows sign options. Will add MSIX package to files.',
+        );
       });
 
       it('it should warn if app dir is not defined and files are empty in windows sign options', async () => {
@@ -471,19 +510,22 @@ describe('utils', () => {
             appDirectory: undefined,
             files: [],
           } as any,
-        }
+        };
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Neither path to application <appDir> nor files <files> provided in windows sign options. Will add MSIX package to files.');
+        expect(log.warn).toHaveBeenCalledWith(
+          'Neither path to application <appDir> nor files <files> provided in windows sign options. Will add MSIX package to files.',
+        );
       });
 
       it('it should warn if no certificate file and no password is provided in windows sign options', async () => {
         const packagingOptions: PackagingOptions = {
           ...minimalPackagingOptions,
-          windowsSignOptions: {
-          } as any,
-        }
+          windowsSignOptions: {} as any,
+        };
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Path to cert <certificateFile> and cert password <certificatePassword> or environment variable WINDOWS_CERTIFICATE_PASSWORD not provided. A dev cert will be created with a random password and the package will be signed with it!');
+        expect(log.warn).toHaveBeenCalledWith(
+          'Path to cert <certificateFile> and cert password <certificatePassword> or environment variable WINDOWS_CERTIFICATE_PASSWORD not provided. A dev cert will be created with a random password and the package will be signed with it!',
+        );
       });
 
       it('it should warn if no certificate file but a password is provided in windows sign options', async () => {
@@ -492,20 +534,23 @@ describe('utils', () => {
           windowsSignOptions: {
             certificatePassword: '123456',
           } as any,
-        }
+        };
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Path to cert <certificateFile> or environment variable WINDOWS_CERTIFICATE_FILE not provided. A dev cert will be created with the provided password and the package will be signed with it!');
+        expect(log.warn).toHaveBeenCalledWith(
+          'Path to cert <certificateFile> or environment variable WINDOWS_CERTIFICATE_FILE not provided. A dev cert will be created with the provided password and the package will be signed with it!',
+        );
       });
 
       it('it should warn if no certificate file but a password is provided via environment variable', async () => {
         const packagingOptions: PackagingOptions = {
           ...minimalPackagingOptions,
-          windowsSignOptions: {
-          } as any,
-        }
+          windowsSignOptions: {} as any,
+        };
         process.env.WINDOWS_CERTIFICATE_PASSWORD = '123456';
         await verifyOptions(packagingOptions);
-        expect(log.warn).toHaveBeenCalledWith('Path to cert <certificateFile> or environment variable WINDOWS_CERTIFICATE_FILE not provided. A dev cert will be created with the provided password and the package will be signed with it!');
+        expect(log.warn).toHaveBeenCalledWith(
+          'Path to cert <certificateFile> or environment variable WINDOWS_CERTIFICATE_FILE not provided. A dev cert will be created with the provided password and the package will be signed with it!',
+        );
       });
 
       it('it should warn a certificate file is provided the file does not exist', async () => {
@@ -515,11 +560,15 @@ describe('utils', () => {
             certificateFile: 'C:\\cert.pfx',
             certificatePassword: '123456',
           } as any,
-        }
+        };
         vi.mocked(fs.exists).mockResolvedValue(false as any);
         await verifyOptions(packagingOptions);
 
-        expect(log.error).toHaveBeenCalledWith('Path to cert <certificateFile> does not exist.', true, { certificateFile: 'C:\\cert.pfx' });
+        expect(log.error).toHaveBeenCalledWith(
+          'Path to cert <certificateFile> does not exist.',
+          true,
+          { certificateFile: 'C:\\cert.pfx' },
+        );
       });
 
       it('it should warn if a certificate file is provided but no password is provided', async () => {
@@ -528,7 +577,7 @@ describe('utils', () => {
           windowsSignOptions: {
             certificateFile: 'C:\\cert.pfx',
           } as any,
-        }
+        };
         vi.mocked(fs.exists).mockResolvedValue(false as any);
         await verifyOptions(packagingOptions);
 
@@ -539,12 +588,13 @@ describe('utils', () => {
         const packagingOptions: PackagingOptions = {
           ...minimalPackagingOptions,
           sign: false,
-          windowsSignOptions: {
-          } as any,
-        }
+          windowsSignOptions: {} as any,
+        };
 
         await verifyOptions(packagingOptions);
-        expect(log.warn).not.toHaveBeenCalledWith('Neither path to application <appDir> nor files <files> provided in windows sign options. Will add MSIX package to files.');
+        expect(log.warn).not.toHaveBeenCalledWith(
+          'Neither path to application <appDir> nor files <files> provided in windows sign options. Will add MSIX package to files.',
+        );
       });
 
       it('it should not warn if a certificate file is provided  no password is provided but the environment variable WINDOWS_CERTIFICATE_PASSWORD is set', async () => {
@@ -553,12 +603,14 @@ describe('utils', () => {
           windowsSignOptions: {
             certificateFile: 'C:\\cert.pfx',
           } as any,
-        }
+        };
         process.env.WINDOWS_CERTIFICATE_PASSWORD = '123456';
         vi.mocked(fs.exists).mockResolvedValue(false as any);
         await verifyOptions(packagingOptions);
 
-        expect(log.warn).not.toHaveBeenCalledWith('Cert password <certificatePassword> not provided.');
+        expect(log.warn).not.toHaveBeenCalledWith(
+          'Cert password <certificatePassword> not provided.',
+        );
       });
 
       it('it should not warn if a certificate file is provided if a password is provided via windows sign options', async () => {
@@ -568,13 +620,14 @@ describe('utils', () => {
             certificateFile: 'C:\\cert.pfx',
             certificatePassword: '123456',
           } as any,
-        }
+        };
         vi.mocked(fs.exists).mockResolvedValue(false as any);
         await verifyOptions(packagingOptions);
 
-        expect(log.warn).not.toHaveBeenCalledWith('Cert password <certificatePassword> not provided.');
+        expect(log.warn).not.toHaveBeenCalledWith(
+          'Cert password <certificatePassword> not provided.',
+        );
       });
-
     });
 
     it('should not throw an error or warning if all manifest variables are provided', async () => {
@@ -600,8 +653,8 @@ describe('utils', () => {
           packageMinOSVersion: '10.0.19041.0',
           packageMaxOSVersionTested: '10.0.19041.0',
           appDisplayName: 'app display name',
-        } as any
-      }
+        } as any,
+      };
 
       vi.mocked(fs.exists).mockResolvedValue(true as any);
       vi.mocked(getCertPublisher).mockResolvedValue('CN=Electron');
@@ -620,15 +673,15 @@ describe('utils', () => {
           files: ['C:\\app\\app.exe'],
         },
         appManifest: 'C:\\app\\app.manifest',
-      }
+      };
 
-      const manifestVariables : ManifestVariables =  {
+      const manifestVariables: ManifestVariables = {
         manifestOsMinVersion: '10.0.19041.0',
         manifestAppName: 'app',
         manifestPackageArch: 'x64',
         manifestIsSparsePackage: false,
-        manifestPublisher: 'Electron'
-      }
+        manifestPublisher: 'Electron',
+      };
 
       vi.mocked(fs.exists).mockResolvedValue(true as any);
       vi.mocked(getCertPublisher).mockResolvedValue('Electron');
@@ -640,26 +693,33 @@ describe('utils', () => {
     it('should throw an error if no app manifest is provided', async () => {
       const packagingOptions: PackagingOptions = {
         ...incompletePackagingOptions,
-      }
+      };
       await verifyOptions(packagingOptions);
-      expect(log.error).toHaveBeenCalledWith('Neither app manifest <appManifest> nor manifest variables <manifestVariables> provided.', true);
+      expect(log.error).toHaveBeenCalledWith(
+        'Neither app manifest <appManifest> nor manifest variables <manifestVariables> provided.',
+        true,
+      );
     });
 
     it('should throw an error if app manifest does not exist', async () => {
       const packagingOptions: PackagingOptions = {
         ...incompletePackagingOptions,
         appManifest: 'C:\\app\\app.manifest',
-      }
+      };
       vi.mocked(fs.exists).mockResolvedValue(false as any);
       await verifyOptions(packagingOptions);
-      expect(log.error).toHaveBeenCalledWith('Path to application manifest <appManifest> does not exist.', true, { appManifest: 'C:\\app\\app.manifest' });
+      expect(log.error).toHaveBeenCalledWith(
+        'Path to application manifest <appManifest> does not exist.',
+        true,
+        { appManifest: 'C:\\app\\app.manifest' },
+      );
     });
 
     it('should throw an error if app dir is not provided', async () => {
       const packagingOptions: PackagingOptions = {
         ...incompletePackagingOptions,
         appManifest: 'C:\\app\\app.manifest',
-      }
+      };
       delete packagingOptions.appDir;
       vi.mocked(fs.exists).mockResolvedValueOnce(true as any);
       await verifyOptions(packagingOptions, { manifestIsSparsePackage: false } as any);
@@ -670,20 +730,26 @@ describe('utils', () => {
       const packagingOptions: PackagingOptions = {
         ...incompletePackagingOptions,
         appManifest: 'C:\\app\\app.manifest',
-      }
-      vi.mocked(fs.exists).mockResolvedValueOnce(true as any).mockResolvedValueOnce(false as any);
+      };
+      vi.mocked(fs.exists)
+        .mockResolvedValueOnce(true as any)
+        .mockResolvedValueOnce(false as any);
       await verifyOptions(packagingOptions, { manifestIsSparsePackage: false } as any);
-      expect(log.error).toHaveBeenCalledWith('Path to application <appDir> does not exist.', true, { appDir: 'C:\\app' });
+      expect(log.error).toHaveBeenCalledWith('Path to application <appDir> does not exist.', true, {
+        appDir: 'C:\\app',
+      });
     });
 
     it('should warn if no package assets is provided', async () => {
       const packagingOptions: PackagingOptions = {
         ...incompletePackagingOptions,
         appManifest: 'C:\\app\\app.manifest',
-        packageAssets: undefined
-      } as any
+        packageAssets: undefined,
+      } as any;
       await verifyOptions(packagingOptions, { manifestIsSparsePackage: false } as any);
-      expect(log.warn).toHaveBeenCalledWith('Path to packages assets <packageAssets> not provided, using default assets.');
+      expect(log.warn).toHaveBeenCalledWith(
+        'Path to packages assets <packageAssets> not provided, using default assets.',
+      );
     });
 
     it('should throw an error if package assets does not exist', async () => {
@@ -691,13 +757,17 @@ describe('utils', () => {
         ...incompletePackagingOptions,
         appManifest: 'C:\\app\\app.manifest',
         packageAssets: 'C:\\assets',
-      } as any
+      } as any;
       vi.mocked(fs.exists)
         .mockResolvedValueOnce(true as any)
         .mockResolvedValueOnce(true as any)
-        .mockResolvedValueOnce(false as any );
+        .mockResolvedValueOnce(false as any);
       await verifyOptions(packagingOptions, { manifestIsSparsePackage: false } as any);
-      expect(log.error).toHaveBeenCalledWith('Path to packages assets provided but <packageAssets> does not exist.', true, { packageAssets: 'C:\\assets' });
+      expect(log.error).toHaveBeenCalledWith(
+        'Path to packages assets provided but <packageAssets> does not exist.',
+        true,
+        { packageAssets: 'C:\\assets' },
+      );
     });
 
     it('should not throw an error if the publisher prefix is missing in the manifest variables but matches the publisher of the cert', async () => {
@@ -712,7 +782,7 @@ describe('utils', () => {
         },
         cert: 'C:\\cert.pfx',
         cert_pass: '123456',
-      } as any
+      } as any;
       vi.mocked(fs.exists).mockResolvedValue(true as any);
       vi.mocked(getCertPublisher).mockResolvedValue('CN=Electron');
       await verifyOptions(packagingOptions);
@@ -727,12 +797,15 @@ describe('utils', () => {
           certificateFile: 'C:\\cert.pfx',
           certificatePassword: '123456',
         },
-      } as any
+      } as any;
       vi.mocked(getCertPublisher).mockResolvedValue('CN=Electron');
       await verifyOptions(packagingOptions, { manifestPublisher: 'Electron' } as any);
-      expect(log.error).toHaveBeenCalledWith('The publisher in the manifest must match the publisher of the cert', false, {manifest_publisher: 'Electron', cert_publisher: 'CN=Electron'});
+      expect(log.error).toHaveBeenCalledWith(
+        'The publisher in the manifest must match the publisher of the cert',
+        false,
+        { manifest_publisher: 'Electron', cert_publisher: 'CN=Electron' },
+      );
     });
-
 
     it('should throw an error if the publisher in the manifest does not match the publisher of the cert', async () => {
       const packagingOptions: PackagingOptions = {
@@ -742,10 +815,14 @@ describe('utils', () => {
           certificateFile: 'C:\\cert.pfx',
           certificatePassword: '123456',
         },
-      } as any
+      } as any;
       vi.mocked(getCertPublisher).mockResolvedValue('Electron');
       await verifyOptions(packagingOptions, { manifestPublisher: 'NotElectron' } as any);
-      expect(log.error).toHaveBeenCalledWith('The publisher in the manifest must match the publisher of the cert', false, {manifest_publisher: 'NotElectron', cert_publisher: 'Electron'});
+      expect(log.error).toHaveBeenCalledWith(
+        'The publisher in the manifest must match the publisher of the cert',
+        false,
+        { manifest_publisher: 'NotElectron', cert_publisher: 'Electron' },
+      );
     });
 
     it('should throw an error if the publisher in the manifest variables does not match the publisher of the cert', async () => {
@@ -761,11 +838,15 @@ describe('utils', () => {
           appExecutable: 'C:\\app\\app.exe',
           targetArch: 'x64',
           packageIdentity: 'Electron.App',
-        } as any
-      } as any
+        } as any,
+      } as any;
       vi.mocked(getCertPublisher).mockResolvedValue('Electron');
       await verifyOptions(packagingOptions, { manifestPublisher: 'NotElectron' } as any);
-      expect(log.error).toHaveBeenCalledWith('The publisher in the manifest must match the publisher of the cert', false, {manifest_publisher: 'NotElectron', cert_publisher: 'Electron'});
+      expect(log.error).toHaveBeenCalledWith(
+        'The publisher in the manifest must match the publisher of the cert',
+        false,
+        { manifest_publisher: 'NotElectron', cert_publisher: 'Electron' },
+      );
     });
   });
 
@@ -792,8 +873,7 @@ describe('utils', () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
         windowsKitPath: 'C:\\windowskit',
-
-      }
+      };
       vi.mocked(fs.exists).mockResolvedValue(true as any);
       const binaries = await locateMSIXTooling(packagingOptions);
       expect(binaries).toBeDefined();
@@ -801,8 +881,9 @@ describe('utils', () => {
         makeAppx: 'C:\\windowskit\\makeappx.exe',
         makePri: 'C:\\windowskit\\makepri.exe',
         makeCert: 'C:\\windowskit\\makecert.exe',
-        signTool: 'C:\\windowskit\\SignTool.exe'});
-   });
+        signTool: 'C:\\windowskit\\SignTool.exe',
+      });
+    });
 
     it('should throw an error if the windows kit path is provided but does not exist', async () => {
       const packagingOptions: PackagingOptions = {
@@ -810,11 +891,15 @@ describe('utils', () => {
         windowsKitPath: 'C:\\windowskit',
         manifestVariables: {
           targetArch: 'x64',
-        } as any
-      }
-      vi.mocked(fs.pathExists).mockResolvedValueOnce(false as any)
-      await locateMSIXTooling(packagingOptions)
-      expect(log.error).toHaveBeenCalledWith('The WindowsKitPath was provided but does not exist.', true, 'C:\\windowskit');
+        } as any,
+      };
+      vi.mocked(fs.pathExists).mockResolvedValueOnce(false as any);
+      await locateMSIXTooling(packagingOptions);
+      expect(log.error).toHaveBeenCalledWith(
+        'The WindowsKitPath was provided but does not exist.',
+        true,
+        'C:\\windowskit',
+      );
     });
 
     it('should log a debug message if the windows kit path is not provided', async () => {
@@ -822,10 +907,12 @@ describe('utils', () => {
         ...minimalPackagingOptions,
         manifestVariables: {
           targetArch: 'x64',
-        } as any
-      }
-      await locateMSIXTooling(packagingOptions)
-      expect(log.debug).toHaveBeenCalledWith('No WindowsKitPath provided. Will try WindowsKitVersion next.');
+        } as any,
+      };
+      await locateMSIXTooling(packagingOptions);
+      expect(log.debug).toHaveBeenCalledWith(
+        'No WindowsKitPath provided. Will try WindowsKitVersion next.',
+      );
     });
 
     it('should return the binaries from the windows kit version if it exists', async () => {
@@ -834,14 +921,19 @@ describe('utils', () => {
         windowsKitVersion: '10.0.14393.42',
         manifestVariables: {
           targetArch: 'x64',
-        } as any      }
+        } as any,
+      };
 
       const binaries = await locateMSIXTooling(packagingOptions);
       expect(binaries).toStrictEqual({
-        makeAppx: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makeappx.exe',
+        makeAppx:
+          'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makeappx.exe',
         makePri: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makepri.exe',
-        makeCert: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makecert.exe',
-        signTool: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\SignTool.exe'});
+        makeCert:
+          'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makecert.exe',
+        signTool:
+          'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\SignTool.exe',
+      });
     });
 
     it('should throw an error if the windows kit version is provided but does not exist', async () => {
@@ -850,11 +942,15 @@ describe('utils', () => {
         windowsKitVersion: '10.0.14393.42',
         manifestVariables: {
           targetArch: 'x64',
-        } as any
-      }
-      vi.mocked(fs.pathExists).mockResolvedValueOnce(false as any)
-      await locateMSIXTooling(packagingOptions)
-      expect(log.error).toHaveBeenCalledWith('WindowsKitVersion was provided but does not exist.', true, 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64');
+        } as any,
+      };
+      vi.mocked(fs.pathExists).mockResolvedValueOnce(false as any);
+      await locateMSIXTooling(packagingOptions);
+      expect(log.error).toHaveBeenCalledWith(
+        'WindowsKitVersion was provided but does not exist.',
+        true,
+        'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64',
+      );
     });
 
     it('should log a debug message if the windows kit version is not provided', async () => {
@@ -862,10 +958,12 @@ describe('utils', () => {
         ...minimalPackagingOptions,
         manifestVariables: {
           targetArch: 'x64',
-        } as any
-      }
-      await locateMSIXTooling(packagingOptions)
-      expect(log.debug).toHaveBeenCalledWith('No WindowsKitVersion provided. Will try AppxManifest.xml min OS version next.');
+        } as any,
+      };
+      await locateMSIXTooling(packagingOptions);
+      expect(log.debug).toHaveBeenCalledWith(
+        'No WindowsKitVersion provided. Will try AppxManifest.xml min OS version next.',
+      );
     });
 
     it('should skip app manifest block and use default binaries when no appManifest and no packageMinOSVersion', async () => {
@@ -879,10 +977,13 @@ describe('utils', () => {
           appExecutable: 'app.exe',
           targetArch: 'x64',
         } as any,
-      }
+      };
       vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
       const binaries = await locateMSIXTooling(packagingOptions);
-      expect(log.debug).toHaveBeenCalledWith('No information on WindowsKitVersion was provided, using default binaries. Checking if it exists....', expect.any(Object));
+      expect(log.debug).toHaveBeenCalledWith(
+        'No information on WindowsKitVersion was provided, using default binaries. Checking if it exists....',
+        expect.any(Object),
+      );
       expect(binaries).toBeDefined();
       expect(binaries?.makeAppx).toContain('10.0.26100.0');
     });
@@ -892,10 +993,13 @@ describe('utils', () => {
         appDir: 'C:\\app',
         outputDir: 'C:\\out',
         manifestVariables: undefined,
-      } as any
+      } as any;
       vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
       const binaries = await locateMSIXTooling(packagingOptions);
-      expect(log.debug).toHaveBeenCalledWith('No information on WindowsKitVersion was provided, using default binaries. Checking if it exists....', expect.any(Object));
+      expect(log.debug).toHaveBeenCalledWith(
+        'No information on WindowsKitVersion was provided, using default binaries. Checking if it exists....',
+        expect.any(Object),
+      );
       expect(binaries).toBeDefined();
     });
 
@@ -903,46 +1007,61 @@ describe('utils', () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
         windowsKitVersion: '10.0.14393.42',
-      }
+      };
       overrideProcessorArchitecture('ARM64');
 
       const binaries = await locateMSIXTooling(packagingOptions);
       expect(binaries).toStrictEqual({
-        makeAppx: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makeappx.exe',
+        makeAppx:
+          'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makeappx.exe',
         makePri: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makepri.exe',
-        makeCert: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makecert.exe',
-        signTool: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\SignTool.exe'});
+        makeCert:
+          'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makecert.exe',
+        signTool:
+          'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\SignTool.exe',
+      });
     });
 
     it('should return binaries derived from the manifest variables if the windows kit version and path is not provided', async () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
-        appManifest: 'C:\\app\\app.manifest'
-      }
+        appManifest: 'C:\\app\\app.manifest',
+      };
 
-      const binaries = await locateMSIXTooling(packagingOptions, { manifestOsMinVersion: '10.0.22621.0', manifestPackageArch: 'x64' } as any);
+      const binaries = await locateMSIXTooling(packagingOptions, {
+        manifestOsMinVersion: '10.0.22621.0',
+        manifestPackageArch: 'x64',
+      } as any);
       expect(binaries).toStrictEqual({
         makeAppx: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\makeappx.exe',
         makePri: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\makepri.exe',
         makeCert: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\makecert.exe',
-        signTool: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\SignTool.exe'});
+        signTool: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\SignTool.exe',
+      });
     });
 
     it('should throw an error if windows kit version derived from the manifest variables does not exist ', async () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
-        appManifest: 'C:\\app\\app.manifest'
-      }
-      vi.mocked(fs.pathExists).mockResolvedValueOnce(false as any)
-      await locateMSIXTooling(packagingOptions, { manifestOsMinVersion: '10.0.22621.0', manifestPackageArch: 'x64' } as any);
-      expect(log.error).toHaveBeenCalledWith('WindowsKitVersion read from AppManifest but WindowsKit does not exist.', true, 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64');
+        appManifest: 'C:\\app\\app.manifest',
+      };
+      vi.mocked(fs.pathExists).mockResolvedValueOnce(false as any);
+      await locateMSIXTooling(packagingOptions, {
+        manifestOsMinVersion: '10.0.22621.0',
+        manifestPackageArch: 'x64',
+      } as any);
+      expect(log.error).toHaveBeenCalledWith(
+        'WindowsKitVersion read from AppManifest but WindowsKit does not exist.',
+        true,
+        'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64',
+      );
     });
 
     it('should throw an error if the manifest variables do not contain a windows kit version', async () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
-         appManifest: 'C:\\app\\app.manifest'
-      }
+        appManifest: 'C:\\app\\app.manifest',
+      };
       await locateMSIXTooling(packagingOptions, { manifestPackageArch: 'arm64' } as any);
       expect(log.error).toHaveBeenCalledWith("Couldn't find Windows Kit version in AppManifest.");
     });
@@ -955,52 +1074,67 @@ describe('utils', () => {
           ...minimalPackagingOptions.manifestVariables,
           packageMinOSVersion: '10.0.22621.0',
         } as any,
-      }
+      };
       const binaries = await locateMSIXTooling(packagingOptions);
       expect(binaries).toStrictEqual({
         makeAppx: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\makeappx.exe',
         makePri: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\makepri.exe',
         makeCert: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\makecert.exe',
-        signTool: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\SignTool.exe'});
+        signTool: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\SignTool.exe',
+      });
     });
 
     it('should return x64 binaries if the target arch is arm64 and the windows kit version is older than 10.0.22621.0', async () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
-        appManifest: 'C:\\app\\app.manifest'
-      }
+        appManifest: 'C:\\app\\app.manifest',
+      };
       overrideProcessorArchitecture('ARM64');
-      const binaries = await locateMSIXTooling(packagingOptions, { manifestOsMinVersion: '10.0.14393.42', manifestPackageArch: 'arm64' } as any);
+      const binaries = await locateMSIXTooling(packagingOptions, {
+        manifestOsMinVersion: '10.0.14393.42',
+        manifestPackageArch: 'arm64',
+      } as any);
       expect(binaries).toStrictEqual({
-        makeAppx: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makeappx.exe',
+        makeAppx:
+          'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makeappx.exe',
         makePri: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makepri.exe',
-        makeCert: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makecert.exe',
-        signTool: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\SignTool.exe'});
+        makeCert:
+          'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\makecert.exe',
+        signTool:
+          'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.14393.42\\x64\\SignTool.exe',
+      });
     });
 
     it('should return default binaries if no information is provided', async () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
-      }
+      };
       overrideProcessorArchitecture('ARM64');
-      vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any)
+      vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
       const binaries = await locateMSIXTooling(packagingOptions);
       expect(binaries).toStrictEqual({
-        makeAppx: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\arm64\\makeappx.exe',
+        makeAppx:
+          'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\arm64\\makeappx.exe',
         makePri: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\arm64\\makepri.exe',
-        makeCert: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\arm64\\makecert.exe',
-        signTool: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\arm64\\SignTool.exe'});
+        makeCert:
+          'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\arm64\\makecert.exe',
+        signTool:
+          'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\arm64\\SignTool.exe',
+      });
     });
 
     it('should throw an error if no binaries are found', async () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
-      }
-      vi.mocked(fs.pathExists).mockResolvedValueOnce(false as any)
+      };
+      vi.mocked(fs.pathExists).mockResolvedValueOnce(false as any);
       await locateMSIXTooling(packagingOptions);
-      expect(log.error).toHaveBeenCalledWith('No information on WindowsKitVersion was provided and default WindowsKit path does not exist.', true, 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\x64');
+      expect(log.error).toHaveBeenCalledWith(
+        'No information on WindowsKitVersion was provided and default WindowsKit path does not exist.',
+        true,
+        'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\x64',
+      );
     });
-
   });
 
   describe('makeProgramOptions', () => {
@@ -1032,11 +1166,11 @@ describe('utils', () => {
     } as any;
 
     const defaultExpectedWindowsSignOptions: SignOptions = {
-      files: ["C:\\out\\app_x64.msix"],
-      certificateFile: "C:\\out\\dev_cert.pfx",
+      files: ['C:\\out\\app_x64.msix'],
+      certificateFile: 'C:\\out\\dev_cert.pfx',
       certificatePassword: expect.any(String),
       hashes: ['sha256'] as any,
-    }
+    };
 
     // const getDefaultSignParams = (cert_pass: string) => {
     //   return ['-fd', 'sha256', '-f', 'C:\\out\\dev_cert.pfx', '-p', cert_pass];
@@ -1058,9 +1192,10 @@ describe('utils', () => {
       const programOptions = await makeProgramOptions(
         {
           ...minimalPackagingOptions,
-          manifestVariables: undefined
+          manifestVariables: undefined,
         },
-        { manifestAppName: 'MyCustomApp', manifestPublisher: 'Electron'} as any);
+        { manifestAppName: 'MyCustomApp', manifestPublisher: 'Electron' } as any,
+      );
 
       expect(programOptions).toStrictEqual({
         ...defaultExpectedProgramOptions,
@@ -1069,7 +1204,8 @@ describe('utils', () => {
           ...defaultExpectedWindowsSignOptions,
           files: ['C:\\out\\MyCustomApp.msix'],
         },
-        msix: 'C:\\out\\MyCustomApp.msix' });
+        msix: 'C:\\out\\MyCustomApp.msix',
+      });
     });
 
     it('should use the app name and package arch from the manifest variables if provided', async () => {
@@ -1077,9 +1213,13 @@ describe('utils', () => {
       const programOptions = await makeProgramOptions(
         {
           ...minimalPackagingOptions,
-          manifestVariables: undefined
+          manifestVariables: undefined,
         },
-        { manifestAppName: 'MyApp', manifestPackageArch: 'arm64', manifestPublisher: 'Electron'} as any
+        {
+          manifestAppName: 'MyApp',
+          manifestPackageArch: 'arm64',
+          manifestPublisher: 'Electron',
+        } as any,
       );
 
       expect(programOptions).toStrictEqual({
@@ -1089,7 +1229,8 @@ describe('utils', () => {
           ...defaultExpectedWindowsSignOptions,
           files: ['C:\\out\\MyApp_arm64.msix'],
         },
-        msix: 'C:\\out\\MyApp_arm64.msix' });
+        msix: 'C:\\out\\MyApp_arm64.msix',
+      });
     });
 
     it('should use the app name and package arch from the manifest variables if provided', async () => {
@@ -1100,8 +1241,8 @@ describe('utils', () => {
           publisher: 'Electron',
           appExecutable: 'MySuperApp.exe',
           packageVersion: '1.2.3',
-        } as any
-      }
+        } as any,
+      };
       vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
       const programOptions = await makeProgramOptions(packagingOptions);
 
@@ -1111,7 +1252,7 @@ describe('utils', () => {
           ...defaultExpectedWindowsSignOptions,
           files: ['C:\\out\\MySuperApp_arm64.msix'],
         },
-        msix: 'C:\\out\\MySuperApp_arm64.msix'
+        msix: 'C:\\out\\MySuperApp_arm64.msix',
       });
     });
 
@@ -1126,20 +1267,20 @@ describe('utils', () => {
           publisher: 'Electron',
           appExecutable: 'MySuperApp.exe',
           packageVersion: '1.2.3',
-        } as any
-      }
+        } as any,
+      };
       vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
       const programOptions = await makeProgramOptions(packagingOptions);
 
       expect(programOptions).toStrictEqual({
         ...defaultExpectedProgramOptions,
         windowsSignOptions: {
-          certificateFile: "C:\\out\\dev_cert.pfx",
+          certificateFile: 'C:\\out\\dev_cert.pfx',
           certificatePassword: expect.any(String),
           hashes: ['sha256'] as any,
           appDirectory: 'C:\\app',
         },
-        msix: 'C:\\out\\MySuperApp_arm64.msix'
+        msix: 'C:\\out\\MySuperApp_arm64.msix',
       });
     });
 
@@ -1152,13 +1293,14 @@ describe('utils', () => {
           packageVersion: '1.2.3',
         } as any,
         createPri: false,
-      }
+      };
       vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
       const programOptions = await makeProgramOptions(packagingOptions);
       expect(programOptions).toStrictEqual({
         ...defaultExpectedProgramOptions,
         windowsSignOptions: defaultExpectedWindowsSignOptions,
-        createPri: false });
+        createPri: false,
+      });
     });
 
     it('should disable compression if compress is false', async () => {
@@ -1170,13 +1312,14 @@ describe('utils', () => {
           packageVersion: '1.2.3',
         } as any,
         compress: false,
-      }
+      };
       vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
       const programOptions = await makeProgramOptions(packagingOptions);
       expect(programOptions).toStrictEqual({
         ...defaultExpectedProgramOptions,
         windowsSignOptions: defaultExpectedWindowsSignOptions,
-        compress: false });
+        compress: false,
+      });
     });
 
     it('should use the sign params if provided', async () => {
@@ -1189,8 +1332,8 @@ describe('utils', () => {
           targetArch: 'x64',
           publisher: 'Electron',
           packageVersion: '1.2.3',
-        } as any
-      }
+        } as any,
+      };
       vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
       const programOptions = await makeProgramOptions(packagingOptions);
       expect(programOptions).toStrictEqual({
@@ -1199,7 +1342,8 @@ describe('utils', () => {
           ...defaultExpectedWindowsSignOptions,
           signWithParams: ['1', '2', '3'],
         },
-        sign: true });
+        sign: true,
+      });
     });
 
     it('should use cert and cert password if provided', async () => {
@@ -1213,8 +1357,8 @@ describe('utils', () => {
           targetArch: 'x64',
           publisher: 'Electron',
           packageVersion: '1.2.3',
-        } as any
-      }
+        } as any,
+      };
       vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
       vi.mocked(getCertPublisher).mockResolvedValueOnce('Electron');
       const programOptions = await makeProgramOptions(packagingOptions);
@@ -1228,7 +1372,7 @@ describe('utils', () => {
         cert_pfx: '',
         cert_cer: '',
         publisher: 'Electron',
-         createDevCert: false,
+        createDevCert: false,
         sign: true,
       });
     });
@@ -1246,7 +1390,7 @@ describe('utils', () => {
           packageVersion: '1.2.3',
         } as any,
         logLevel: 'debug',
-      }
+      };
       vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
       const programOptions = await makeProgramOptions(packagingOptions);
 
@@ -1276,8 +1420,8 @@ describe('utils', () => {
           targetArch: 'x64',
           publisher: 'Electron',
           packageVersion: '1.2.3',
-        } as any
-      }
+        } as any,
+      };
       vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
       const programOptions = await makeProgramOptions(packagingOptions);
       expect(programOptions).toStrictEqual({
@@ -1297,9 +1441,11 @@ describe('utils', () => {
     it('should use manifest variables publisher if provided', async () => {
       const packagingOptions: PackagingOptions = {
         ...incompletePackagingOptions,
-      }
+      };
       vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
-      const programOptions = await makeProgramOptions(packagingOptions, { manifestPublisher: 'MyPublisher' } as any);
+      const programOptions = await makeProgramOptions(packagingOptions, {
+        manifestPublisher: 'MyPublisher',
+      } as any);
       expect(programOptions).toStrictEqual({
         ...defaultExpectedProgramOptions,
         appManifestIn: null,
@@ -1315,9 +1461,9 @@ describe('utils', () => {
     it('should use empty publisher if no publisher is provided', async () => {
       const packagingOptions: PackagingOptions = {
         ...incompletePackagingOptions,
-      }
+      };
       vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
-      const programOptions = await makeProgramOptions(packagingOptions, {  } as any);
+      const programOptions = await makeProgramOptions(packagingOptions, {} as any);
       expect(programOptions).toStrictEqual({
         ...defaultExpectedProgramOptions,
         appManifestIn: null,
@@ -1334,7 +1480,7 @@ describe('utils', () => {
       const packagingOptions: PackagingOptions = {
         ...minimalPackagingOptions,
         sign: false,
-      }
+      };
       vi.mocked(fs.pathExists).mockResolvedValueOnce(true as any);
       const programOptions = await makeProgramOptions(packagingOptions);
       expect(programOptions).toStrictEqual({
@@ -1364,11 +1510,14 @@ describe('utils', () => {
         appLayout: 'C:\\out\\msix_layout\\app',
         appDir: 'C:\\my_app',
         isSparsePackage: false,
-      } as any
+      } as any;
       vi.mocked(fs.writeFile).mockResolvedValueOnce(undefined);
       vi.mocked(fs.copy).mockResolvedValueOnce(undefined);
       await createLayout(programOptions);
-      expect(fs.writeFile).toHaveBeenCalledWith('C:\\out\\msix_layout\\AppxManifest.xml', 'content');
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        'C:\\out\\msix_layout\\AppxManifest.xml',
+        'content',
+      );
       expect(fs.copy).toHaveBeenCalledWith('C:\\my_assets', 'C:\\out\\msix_layout\\assets');
       expect(fs.copy).toHaveBeenCalledWith('C:\\my_app', 'C:\\out\\msix_layout\\app');
     });
@@ -1381,11 +1530,14 @@ describe('utils', () => {
         assetsLayout: 'C:\\out\\msix_layout\\assets',
         appLayout: 'C:\\out\\msix_layout\\app',
         isSparsePackage: true,
-      } as any
+      } as any;
       vi.mocked(fs.writeFile).mockResolvedValueOnce(undefined);
       vi.mocked(fs.copy).mockResolvedValueOnce(undefined);
       await createLayout(programOptions);
-      expect(fs.writeFile).toHaveBeenCalledWith('C:\\out\\msix_layout\\AppxManifest.xml', 'content');
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        'C:\\out\\msix_layout\\AppxManifest.xml',
+        'content',
+      );
       expect(fs.copy).toBeCalledTimes(1);
       expect(fs.copy).toHaveBeenCalledWith('C:\\my_assets', 'C:\\out\\msix_layout\\assets');
     });

--- a/test/unit/vitest.config.ts
+++ b/test/unit/vitest.config.ts
@@ -1,22 +1,18 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     name: 'unit',
-    include: [
-      'test/unit/*.spec.ts',
-    ],
+    include: ['test/unit/*.spec.ts'],
     coverage: {
       provider: 'istanbul',
       reporter: ['text', 'lcov'], // text for console, lcov for tooling
       reportsDirectory: './coverage',
-      include: [
-        'src/**',
-      ],
+      include: ['src/**'],
       exclude: [
         'src/logger.ts', // Not necessary to test
         'src/index.ts', // Everything is covered by other tests
-      ]
+      ],
     },
   },
-})
+});

--- a/test/unit/win-version.spec.ts
+++ b/test/unit/win-version.spec.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it } from 'vitest'
+import { expect, describe, it } from 'vitest';
 import { ensureWindowsVersion, WindowsOSVersion } from '../../src/win-version';
 
 describe('win-version', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "compilerOptions": {
-    "module": "CommonJS",
+    "module": "Node16",
     "esModuleInterop": true,
     "target": "ES2022",
-    "moduleResolution": "Node",
+    "moduleResolution": "Node16",
     "sourceMap": true,
     "declaration": true,
+    "rootDir": "src",
     "outDir": "lib",
     "skipLibCheck": true,
     "lib": ["ES2022"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,7 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: [
-      'test/unit/**/*.spec.ts',
-      'test/e2e/**/*.spec.ts'
-    ]
+    include: ['test/unit/**/*.spec.ts', 'test/e2e/**/*.spec.ts'],
   },
-})
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -340,6 +340,226 @@
   dependencies:
     cross-spawn "^7.0.1"
 
+"@oxfmt/binding-android-arm-eabi@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.44.0.tgz#5974105a730c44c7404ef163c5b8b686682fa06d"
+  integrity sha512-5UvghMd9SA/yvKTWCAxMAPXS1d2i054UeOf4iFjZjfayTwCINcC3oaSXjtbZfCaEpxgJod7XiOjTtby5yEv/BQ==
+
+"@oxfmt/binding-android-arm64@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.44.0.tgz#77f553e42571b99cae390baadc237a84207178bd"
+  integrity sha512-IVudM1BWfvrYO++Khtzr8q9n5Rxu7msUvoFMqzGJVdX7HfUXUDHwaH2zHZNB58svx2J56pmCUzophyaPFkcG/A==
+
+"@oxfmt/binding-darwin-arm64@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.44.0.tgz#a43262f59aa8da667db53ba3d454ef1afcef3e18"
+  integrity sha512-eWCLAIKAHfx88EqEP1Ga2yz7qVcqDU5lemn4xck+07bH182hDdprOHjbogyk0In1Djys3T0/pO2JepFnRJ41Mg==
+
+"@oxfmt/binding-darwin-x64@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.44.0.tgz#cd95251cfc545f26a6ee7e664d5bd6df71b4f567"
+  integrity sha512-eHTBznHLM49++dwz07MblQ2cOXyIgeedmE3Wgy4ptUESj38/qYZyRi1MPwC9olQJWssMeY6WI3UZ7YmU5ggvyQ==
+
+"@oxfmt/binding-freebsd-x64@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.44.0.tgz#eb3234a5a3c63346d134c3823cc763e01924be01"
+  integrity sha512-jLMmbj0u0Ft43QpkUVr/0v1ZfQCGWAvU+WznEHcN3wZC/q6ox7XeSJtk9P36CCpiDSUf3sGnzbIuG1KdEMEDJQ==
+
+"@oxfmt/binding-linux-arm-gnueabihf@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.44.0.tgz#b939bc27eb8be72c7e689b9307ed6086dc683059"
+  integrity sha512-n+A/u/ByK1qV8FVGOwyaSpw5NPNl0qlZfgTBqHeGIqr8Qzq1tyWZ4lAaxPoe5mZqE3w88vn3+jZtMxriHPE7tg==
+
+"@oxfmt/binding-linux-arm-musleabihf@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.44.0.tgz#0725a2d091643a00bbacdffaa12e377abf32606c"
+  integrity sha512-5eax+FkxyCqAi3Rw0mrZFr7+KTt/XweFsbALR+B5ljWBLBl8nHe4ADrUnb1gLEfQCJLl+Ca5FIVD4xEt95AwIw==
+
+"@oxfmt/binding-linux-arm64-gnu@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.44.0.tgz#416e68d5e536fa19ca8499611fca9928cc2ee9d4"
+  integrity sha512-58l8JaHxSGOmOMOG2CIrNsnkRJAj0YcHQCmvNACniOa/vd1iRHhlPajczegzS5jwMENlqgreyiTR9iNlke8qCw==
+
+"@oxfmt/binding-linux-arm64-musl@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.44.0.tgz#8bb3bd2461b354caa443d093471b347547426e8a"
+  integrity sha512-AlObQIXyVRZ96LbtVljtFq0JqH5B92NU+BQeDFrXWBUWlCKAM0wF5GLfIhCLT5kQ3Sl+U0YjRJ7Alqj5hGQaCg==
+
+"@oxfmt/binding-linux-ppc64-gnu@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.44.0.tgz#427a2278fa9aff179d2c66dce29dabe78f907474"
+  integrity sha512-YcFE8/q/BbrCiIiM5piwbkA6GwJc5QqhMQp2yDrqQ2fuVkZ7CInb1aIijZ/k8EXc72qXMSwKpVlBv1w/MsGO/A==
+
+"@oxfmt/binding-linux-riscv64-gnu@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.44.0.tgz#587c4381de6e30d9302ddc4b3f40b0cd7af209ee"
+  integrity sha512-eOdzs6RqkRzuqNHUX5C8ISN5xfGh4xDww8OEd9YAmc3OWN8oAe5bmlIqQ+rrHLpv58/0BuU48bxkhnIGjA/ATQ==
+
+"@oxfmt/binding-linux-riscv64-musl@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.44.0.tgz#c9e41aa68ebad6966642ef4df4fac17cdd67fa34"
+  integrity sha512-YBgNTxntD/QvlFUfgvh8bEdwOhXiquX8gaofZJAwYa/Xp1S1DQrFVZEeck7GFktr24DztsSp8N8WtWCBwxs0Hw==
+
+"@oxfmt/binding-linux-s390x-gnu@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.44.0.tgz#c04ffde3e1e2703704fcdf3875ba08b0c2881334"
+  integrity sha512-GLIh1R6WHWshl/i4QQDNgj0WtT25aRO4HNUWEoitxiywyRdhTFmFEYT2rXlcl9U6/26vhmOqG5cRlMLG3ocaIA==
+
+"@oxfmt/binding-linux-x64-gnu@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.44.0.tgz#b3109a3c8bebb42612d3c684c251d2cdd614c94e"
+  integrity sha512-gZOpgTlOsLcLfAF9qgpTr7FIIFSKnQN3hDf/0JvQ4CIwMY7h+eilNjxq/CorqvYcEOu+LRt1W4ZS7KccEHLOdA==
+
+"@oxfmt/binding-linux-x64-musl@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.44.0.tgz#26a3c17c0bb4d171cd582986cddbad188ff9534d"
+  integrity sha512-1CyS9JTB+pCUFYFI6pkQGGZaT/AY5gnhHVrQQLhFba6idP9AzVYm1xbdWfywoldTYvjxQJV6x4SuduCIfP3W+A==
+
+"@oxfmt/binding-openharmony-arm64@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.44.0.tgz#2702d7cfc86821e55878c2bffba5f75430d5107a"
+  integrity sha512-bmEv70Ak6jLr1xotCbF5TxIKjsmQaiX+jFRtnGtfA03tJPf6VG3cKh96S21boAt3JZc+Vjx8PYcDuLj39vM2Pw==
+
+"@oxfmt/binding-win32-arm64-msvc@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.44.0.tgz#c0ebbde2b30452d0d36adaa2cb566ab6c31849f0"
+  integrity sha512-yWzB+oCpSnP/dmw85eFLAT5o35Ve5pkGS2uF/UCISpIwDqf1xa7OpmtomiqY/Vzg8VyvMbuf6vroF2khF/+1Vg==
+
+"@oxfmt/binding-win32-ia32-msvc@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.44.0.tgz#b6cba86c0f87a95648a10ef3482aa1a1c1d18de9"
+  integrity sha512-TcWpo18xEIE3AmIG2kpr3kz5IEhQgnx0lazl2+8L+3eTopOAUevQcmlr4nhguImNWz0OMeOZrYZOhJNCf16nlQ==
+
+"@oxfmt/binding-win32-x64-msvc@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.44.0.tgz#61ce119e828b46e2c89254f05529a8c2f7ee25f1"
+  integrity sha512-oj8aLkPJZppIM4CMQNsyir9ybM1Xw/CfGPTSsTnzpVGyljgfbdP0EVUlURiGM0BDrmw5psQ6ArmGCcUY/yABaQ==
+
+"@oxlint-tsgolint/darwin-arm64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.20.0.tgz#6d704883904fa6e5fc922a7cef882bad4c734a0b"
+  integrity sha512-KKQcIHZHMxqpHUA1VXIbOG6chNCFkUWbQy6M+AFVtPKkA/3xAeJkJ3njoV66bfzwPHRcWQO+kcj5XqtbkjakoA==
+
+"@oxlint-tsgolint/darwin-x64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.20.0.tgz#676d7a1cf82216d91e9bc143f676e7dbe59ce596"
+  integrity sha512-7HeVMuclGfG+NLZi2ybY0T4fMI7/XxO/208rJk+zEIloKkVnlh11Wd241JMGwgNFXn+MLJbOqOfojDb2Dt4L1g==
+
+"@oxlint-tsgolint/linux-arm64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.20.0.tgz#5a2e67cf18394b6b868301cf3d84c8b8be7ab6b9"
+  integrity sha512-zxhUwz+WSxE6oWlZLK2z2ps9yC6ebmgoYmjAl0Oa48+GqkZ56NVgo+wb8DURNv6xrggzHStQxqQxe3mK51HZag==
+
+"@oxlint-tsgolint/linux-x64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@oxlint-tsgolint/linux-x64/-/linux-x64-0.20.0.tgz#68468ad9253668748736191b6a7af51ae737c0a4"
+  integrity sha512-/1l6FnahC9im8PK+Ekkx/V3yetO/PzZnJegE2FXcv/iXEhbeVxP/ouiTYcUQu9shT1FWJCSNti1VJHH+21Y1dg==
+
+"@oxlint-tsgolint/win32-arm64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.20.0.tgz#32a0eba60f0a88cd6d6d53cc03eb1b2e43ca0c50"
+  integrity sha512-oPZ5Yz8sVdo7P/5q+i3IKeix31eFZ55JAPa1+RGPoe9PoaYVsdMvR6Jvib6YtrqoJnFPlg3fjEjlEPL8VBKYJA==
+
+"@oxlint-tsgolint/win32-x64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@oxlint-tsgolint/win32-x64/-/win32-x64-0.20.0.tgz#90d5582b1df2ae877b2c5d7620e3a55acf9cc45f"
+  integrity sha512-4stx8RHj3SP9vQyRF/yZbz5igtPvYMEUR8CUoha4BVNZihi39DpCR8qkU7lpjB5Ga1DRMo2pHaA4bdTOMaY4mw==
+
+"@oxlint/binding-android-arm-eabi@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.69.0.tgz#ff9bdf70a7d8afc5d25e561a6a11cbcb5dca7904"
+  integrity sha512-DKQQbD5cZ/MYfDgDI7YGyGD9FSxABlsBsYFo5p26lloob543tP9+4N3guwdXIYJN+7HSZxLe8YJuwcOWw5qnHg==
+
+"@oxlint/binding-android-arm64@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-android-arm64/-/binding-android-arm64-1.69.0.tgz#ab6fd3222bae278cc166e6e8e343191658c1e3d4"
+  integrity sha512-lEhb+I5pr4inux+JFwfCa1HRq3Os7NirEFQ0H1I35SVEHPm6byX0Ah47xmRha3qi6LAkxUcxViL8o/9PivjzBg==
+
+"@oxlint/binding-darwin-arm64@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.69.0.tgz#6051d22e4f928c2aa65cfe8d65544fe62ca60ac9"
+  integrity sha512-GY2YE8lOZW59BW1Ia1y+1gR0XyjrZRvVWHAr8LGeGhYHE0OQJ/7cRKXTkx1P+E9/6awEc3SX8a68SFTjh/E//A==
+
+"@oxlint/binding-darwin-x64@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.69.0.tgz#d4de7d24221f9f5bfa593a680e57f0b21af56c15"
+  integrity sha512-ax1oZnOjHX3LB7myQyHEaQkDwfLb6str3/nSP6O7EVUviQGNkEGzGV0EqcBJWK+Ufwx0l4xPgyYayurvhAdl2Q==
+
+"@oxlint/binding-freebsd-x64@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.69.0.tgz#e9879bf639dc1bc317e30923075d775e101bc2b5"
+  integrity sha512-kHWeHv4g2h8NY+mpCxzCtY4uerMJWTN/TSnNj1CPbakFpHEJ6cTya2wWV0pDSYWOJ2+0UiEbhn3AtXxHtsnKjg==
+
+"@oxlint/binding-linux-arm-gnueabihf@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.69.0.tgz#6361e85a66b0e7507c13c18ce69fdba91945e7f6"
+  integrity sha512-gq84vM1a1oEehXo27YCDzGVcxPsZDI1yswZwz2Da1/cbnWtrL16XZZnz0G/+gIU8edtHpfjxq5c+vWEHqJfWoQ==
+
+"@oxlint/binding-linux-arm-musleabihf@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.69.0.tgz#f4561452a78356b58c8f7adf97a156e5782acb2c"
+  integrity sha512-kIqEa98JQ0VRyrcncxA417m2AzasqTlD+FyVT1AksjvjkqQcvm7pBWYvoW3/mpyOP2XYvi5nSCCTIe6De1yu5g==
+
+"@oxlint/binding-linux-arm64-gnu@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.69.0.tgz#7a43e689cb18b3e1678633b23390fa20bd1cbda7"
+  integrity sha512-j+xYiXozxGWx2cpjCrwwGR4awTxPFsRv3JZrv23RCogEPMc4R7UqjHW47p/RG0aRlbWiROCJ8coUfCwy0dvzHA==
+
+"@oxlint/binding-linux-arm64-musl@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.69.0.tgz#be8540a20a505c8a1c3cb6c1b9a5532aed543458"
+  integrity sha512-xEPpNppTfN1l/nM7gYSf9iocscu/as+p/7vxkLeLEKnYU+09Dm+5V6IhDYDh+Uz6FajEupWwCLt5SOG0y1PCKg==
+
+"@oxlint/binding-linux-ppc64-gnu@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.69.0.tgz#14c76efdad9e5d4e2d3fbb40f2cae87e943ee21f"
+  integrity sha512-Ug0+eU7HJBlek+SjklYH62IlOMirEJsdxpihH0kSqX0XdrDD4NdHpQc10fK1JC35yn6KrrcN+uYzlHD38XAf8Q==
+
+"@oxlint/binding-linux-riscv64-gnu@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.69.0.tgz#c59dffa324871b07e68eda7d2c9a8e2ee79853c8"
+  integrity sha512-iEyI3GIg0l/s3G4qy2TlaaWKdzj4PJJStwtlocpDTC00PY9hZueotf6OKUj9+yfQh0lrpBW/pLMgTztbAHKJEg==
+
+"@oxlint/binding-linux-riscv64-musl@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.69.0.tgz#7916699304593dbd3089cd759038e076add2df59"
+  integrity sha512-NjHjpiI4WIKSMwuoJSZi5VToPeoYOS1FR52HLIDG6lidMdqquusgtODb4iLk0+lb1q3Z0nv2/aPRcC/olmpQGg==
+
+"@oxlint/binding-linux-s390x-gnu@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.69.0.tgz#4b3e47b3b4d3af73a0c55b253aaaa5029e617478"
+  integrity sha512-Ai/prDewoItkDXbp38gwGZi41DycZbUTZJ3UidwoHgQC0/DaqC2TGdtBTQLJ6hSD+SAxASzh8+/eSBPmxfOacA==
+
+"@oxlint/binding-linux-x64-gnu@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.69.0.tgz#dd6ada2a7200fdad962786383deac3324cdab428"
+  integrity sha512-Gt3KHgp46mRKz4sJeaASmKvD8ayXookRw07RMf+NowhEztGGDZ7VrXpoW96XuKJLjFukWizOFVNjmYb/u7caNQ==
+
+"@oxlint/binding-linux-x64-musl@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.69.0.tgz#ce3f70743aaba11c7be76e7b860a91443441dc83"
+  integrity sha512-7tQhJ2+p/oHv1zcfnjYI7YVzC/7iBaVOfIvFYtxdJ5F45mWgEdrCyXZXZGfiLey5t/5JhOhsaMnnv1kAzckd7g==
+
+"@oxlint/binding-openharmony-arm64@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.69.0.tgz#fc2f46c00661b3f06905aeae0c04685f7bbf6ea2"
+  integrity sha512-vmWz6TKp/3hfA4lksR0zHBv/6xuX1jhym6eqOjdH2DXsDDHZWcp2f0KG0VCAnlVbIrjk29G4wAWMXb/Hn1YobA==
+
+"@oxlint/binding-win32-arm64-msvc@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.69.0.tgz#4f242cdc4cf3a3560d75d3619121dfa28abb9254"
+  integrity sha512-9RExaLgmaw6IoIkU9cTpT71mLfI0xZ86iZH8x518LVsOkjquJMYqb9P7KpC8lgd1t0Dxs41p2pxynq4XR3Ttzw==
+
+"@oxlint/binding-win32-ia32-msvc@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.69.0.tgz#14ad272be67655e2504821697122267f885a7154"
+  integrity sha512-1907kRPF8/PrcIw1E7LMs9JbVrpgnt/MvFdss3an8oDkYNAACXzTntV3t3869ZZhMZxb2AzRGbz1pA/jdFatXA==
+
+"@oxlint/binding-win32-x64-msvc@1.69.0":
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.69.0.tgz#592c92384e9d8000f6a8f90d2cd74a24f505813b"
+  integrity sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -561,6 +781,13 @@
     loupe "^3.1.4"
     tinyrainbow "^2.0.0"
 
+ansi-escapes@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.3.0.tgz#5395bb74b2150a4a1d6e3c2565f4aeca78d28627"
+  integrity sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==
+  dependencies:
+    environment "^1.0.0"
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -570,6 +797,11 @@ ansi-regex@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.1.0.tgz#95ec409c69619d6cb1b8b34f14b660ef28ebd654"
   integrity sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==
+
+ansi-regex@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
@@ -582,6 +814,11 @@ ansi-styles@^6.1.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
+
+ansi-styles@^6.2.1, ansi-styles@^6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 assertion-error@^2.0.1:
   version "2.0.1"
@@ -644,6 +881,21 @@ check-error@^2.1.1:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
   integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
 
+cli-cursor@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-5.0.0.tgz#24a4831ecf5a6b01ddeb32fb71a4b2088b0dce38"
+  integrity sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==
+  dependencies:
+    restore-cursor "^5.0.0"
+
+cli-truncate@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-5.2.0.tgz#c8e72aaca8339c773d128c36e0a17c6315b694eb"
+  integrity sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==
+  dependencies:
+    slice-ansi "^8.0.0"
+    string-width "^8.2.0"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -655,6 +907,16 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+colorette@^2.0.20:
+  version "2.0.20"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
+  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+
+commander@^14.0.3:
+  version "14.0.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.3.tgz#425d79b48f9af82fcd9e4fc1ea8af6c5ec07bbc2"
+  integrity sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==
 
 commander@^9.4.0:
   version "9.5.0"
@@ -702,6 +964,11 @@ electron-to-chromium@^1.5.173:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.182.tgz#4ab73104f893938acb3ab9c28d7bec170c116b3e"
   integrity sha512-Lv65Btwv9W4J9pyODI6EWpdnhfvrve/us5h1WspW8B2Fb0366REPtY3hX7ounk1CkV/TBjWCEvCBBbYbmV0qCA==
 
+emoji-regex@^10.3.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.6.0.tgz#bf3d6e8f7f8fd22a65d9703475bc0147357a6b0d"
+  integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -711,6 +978,11 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+environment@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/environment/-/environment-1.1.0.tgz#8e86c66b180f363c7ab311787e0259665f45a9f1"
+  integrity sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==
 
 es-module-lexer@^1.7.0:
   version "1.7.0"
@@ -761,6 +1033,11 @@ estree-walker@^3.0.3:
   dependencies:
     "@types/estree" "^1.0.0"
 
+eventemitter3@^5.0.1:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.4.tgz#a86d66170433712dde814707ac52b5271ceb1feb"
+  integrity sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==
+
 expect-type@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.2.tgz#c030a329fb61184126c8447585bc75a7ec6fbff3"
@@ -807,6 +1084,11 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
+get-east-asian-width@^1.0.0, get-east-asian-width@^1.3.1, get-east-asian-width@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz#216900f91df11a8b2c198c3e1d93d6c035a776b9"
+  integrity sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==
+
 glob@^10.4.1:
   version "10.4.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
@@ -834,10 +1116,22 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+husky@^9.1.7:
+  version "9.1.7"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
+  integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
+
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
+is-fullwidth-code-point@^5.0.0, is-fullwidth-code-point@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz#046b2a6d4f6b156b2233d3207d4b5a9783999b98"
+  integrity sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==
+  dependencies:
+    get-east-asian-width "^1.3.1"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -924,6 +1218,41 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+lint-staged@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-16.4.0.tgz#a00b0e3abff59239cef6d7d9341e8f8473308e23"
+  integrity sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==
+  dependencies:
+    commander "^14.0.3"
+    listr2 "^9.0.5"
+    picomatch "^4.0.3"
+    string-argv "^0.3.2"
+    tinyexec "^1.0.4"
+    yaml "^2.8.2"
+
+listr2@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-9.0.5.tgz#92df7c4416a6da630eb9ef46da469b70de97b316"
+  integrity sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==
+  dependencies:
+    cli-truncate "^5.0.0"
+    colorette "^2.0.20"
+    eventemitter3 "^5.0.1"
+    log-update "^6.1.0"
+    rfdc "^1.4.1"
+    wrap-ansi "^9.0.0"
+
+log-update@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-6.1.0.tgz#1a04ff38166f94647ae1af562f4bd6a15b1b7cd4"
+  integrity sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==
+  dependencies:
+    ansi-escapes "^7.0.0"
+    cli-cursor "^5.0.0"
+    slice-ansi "^7.1.0"
+    strip-ansi "^7.1.0"
+    wrap-ansi "^9.0.0"
+
 loupe@^3.1.0, loupe@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.4.tgz#784a0060545cb38778ffb19ccde44d7870d5fdd9"
@@ -964,6 +1293,11 @@ make-dir@^4.0.0:
   dependencies:
     semver "^7.5.3"
 
+mimic-function@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
+  integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
+
 minimatch@^9.0.4:
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
@@ -995,6 +1329,77 @@ node-releases@^2.0.19:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.19.tgz#9e445a52950951ec4d177d843af370b411caf314"
   integrity sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==
+
+onetime@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-7.0.0.tgz#9f16c92d8c9ef5120e3acd9dd9957cceecc1ab60"
+  integrity sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==
+  dependencies:
+    mimic-function "^5.0.0"
+
+oxfmt@^0.44.0:
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/oxfmt/-/oxfmt-0.44.0.tgz#36ba90ef3fc958d37e01d38a3024c3f3dc0ff055"
+  integrity sha512-lnncqvHewyRvaqdrnntVIrZV2tEddz8lbvPsQzG/zlkfvgZkwy0HP1p/2u1aCDToeg1jb9zBpbJdfkV73Itw+w==
+  dependencies:
+    tinypool "2.1.0"
+  optionalDependencies:
+    "@oxfmt/binding-android-arm-eabi" "0.44.0"
+    "@oxfmt/binding-android-arm64" "0.44.0"
+    "@oxfmt/binding-darwin-arm64" "0.44.0"
+    "@oxfmt/binding-darwin-x64" "0.44.0"
+    "@oxfmt/binding-freebsd-x64" "0.44.0"
+    "@oxfmt/binding-linux-arm-gnueabihf" "0.44.0"
+    "@oxfmt/binding-linux-arm-musleabihf" "0.44.0"
+    "@oxfmt/binding-linux-arm64-gnu" "0.44.0"
+    "@oxfmt/binding-linux-arm64-musl" "0.44.0"
+    "@oxfmt/binding-linux-ppc64-gnu" "0.44.0"
+    "@oxfmt/binding-linux-riscv64-gnu" "0.44.0"
+    "@oxfmt/binding-linux-riscv64-musl" "0.44.0"
+    "@oxfmt/binding-linux-s390x-gnu" "0.44.0"
+    "@oxfmt/binding-linux-x64-gnu" "0.44.0"
+    "@oxfmt/binding-linux-x64-musl" "0.44.0"
+    "@oxfmt/binding-openharmony-arm64" "0.44.0"
+    "@oxfmt/binding-win32-arm64-msvc" "0.44.0"
+    "@oxfmt/binding-win32-ia32-msvc" "0.44.0"
+    "@oxfmt/binding-win32-x64-msvc" "0.44.0"
+
+oxlint-tsgolint@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/oxlint-tsgolint/-/oxlint-tsgolint-0.20.0.tgz#e011319219faa572faf340c40d65708404b37e10"
+  integrity sha512-/Uc9TQyN1l8w9QNvXtVHYtz+SzDJHKpb5X0UnHodl0BVzijUPk0LPlDOHAvogd1UI+iy9ZSF6gQxEqfzUxCULQ==
+  optionalDependencies:
+    "@oxlint-tsgolint/darwin-arm64" "0.20.0"
+    "@oxlint-tsgolint/darwin-x64" "0.20.0"
+    "@oxlint-tsgolint/linux-arm64" "0.20.0"
+    "@oxlint-tsgolint/linux-x64" "0.20.0"
+    "@oxlint-tsgolint/win32-arm64" "0.20.0"
+    "@oxlint-tsgolint/win32-x64" "0.20.0"
+
+oxlint@^1.59.0:
+  version "1.69.0"
+  resolved "https://registry.yarnpkg.com/oxlint/-/oxlint-1.69.0.tgz#be7d8f961e91fa43cf1d4e1be6c841d5890cb1d1"
+  integrity sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==
+  optionalDependencies:
+    "@oxlint/binding-android-arm-eabi" "1.69.0"
+    "@oxlint/binding-android-arm64" "1.69.0"
+    "@oxlint/binding-darwin-arm64" "1.69.0"
+    "@oxlint/binding-darwin-x64" "1.69.0"
+    "@oxlint/binding-freebsd-x64" "1.69.0"
+    "@oxlint/binding-linux-arm-gnueabihf" "1.69.0"
+    "@oxlint/binding-linux-arm-musleabihf" "1.69.0"
+    "@oxlint/binding-linux-arm64-gnu" "1.69.0"
+    "@oxlint/binding-linux-arm64-musl" "1.69.0"
+    "@oxlint/binding-linux-ppc64-gnu" "1.69.0"
+    "@oxlint/binding-linux-riscv64-gnu" "1.69.0"
+    "@oxlint/binding-linux-riscv64-musl" "1.69.0"
+    "@oxlint/binding-linux-s390x-gnu" "1.69.0"
+    "@oxlint/binding-linux-x64-gnu" "1.69.0"
+    "@oxlint/binding-linux-x64-musl" "1.69.0"
+    "@oxlint/binding-openharmony-arm64" "1.69.0"
+    "@oxlint/binding-win32-arm64-msvc" "1.69.0"
+    "@oxlint/binding-win32-ia32-msvc" "1.69.0"
+    "@oxlint/binding-win32-x64-msvc" "1.69.0"
 
 package-json-from-dist@^1.0.0:
   version "1.0.1"
@@ -1034,6 +1439,11 @@ picomatch@^4.0.2:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
   integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
 
+picomatch@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
 postcss@^8.5.6:
   version "8.5.6"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
@@ -1049,6 +1459,19 @@ postject@^1.0.0-alpha.6:
   integrity sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==
   dependencies:
     commander "^9.4.0"
+
+restore-cursor@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-5.1.0.tgz#0766d95699efacb14150993f55baf0953ea1ebe7"
+  integrity sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==
+  dependencies:
+    onetime "^7.0.0"
+    signal-exit "^4.1.0"
+
+rfdc@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
+  integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
 rollup@^4.40.0:
   version "4.44.2"
@@ -1106,10 +1529,26 @@ siginfo@^2.0.0:
   resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
 
-signal-exit@^4.0.1:
+signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
+slice-ansi@^7.1.0:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-7.1.2.tgz#adf7be70aa6d72162d907cd0e6d5c11f507b5403"
+  integrity sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==
+  dependencies:
+    ansi-styles "^6.2.1"
+    is-fullwidth-code-point "^5.0.0"
+
+slice-ansi@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-8.0.0.tgz#22d0b66d18bc5c57f488bfcf36cbde3bef731537"
+  integrity sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==
+  dependencies:
+    ansi-styles "^6.2.3"
+    is-fullwidth-code-point "^5.1.0"
 
 source-map-js@^1.2.0, source-map-js@^1.2.1:
   version "1.2.1"
@@ -1125,6 +1564,11 @@ std-env@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.9.0.tgz#1a6f7243b339dca4c9fd55e1c7504c77ef23e8f1"
   integrity sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==
+
+string-argv@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
+  integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
@@ -1153,6 +1597,23 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
+string-width@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
+  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
+  dependencies:
+    emoji-regex "^10.3.0"
+    get-east-asian-width "^1.0.0"
+    strip-ansi "^7.1.0"
+
+string-width@^8.2.0:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-8.2.1.tgz#165089cfa527cc88fbc23dd73313f5e334af1ea1"
+  integrity sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==
+  dependencies:
+    get-east-asian-width "^1.5.0"
+    strip-ansi "^7.1.2"
+
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -1173,6 +1634,13 @@ strip-ansi@^7.0.1:
   integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
   dependencies:
     ansi-regex "^6.0.1"
+
+strip-ansi@^7.1.0, strip-ansi@^7.1.2:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
 
 strip-literal@^3.0.0:
   version "3.0.0"
@@ -1207,6 +1675,11 @@ tinyexec@^0.3.2:
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
   integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
 
+tinyexec@^1.0.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.2.4.tgz#ae45bb2edebda94c70f4ea897e0f1243e470db71"
+  integrity sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==
+
 tinyglobby@^0.2.14:
   version "0.2.14"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.14.tgz#5280b0cf3f972b050e74ae88406c0a6a58f4079d"
@@ -1214,6 +1687,11 @@ tinyglobby@^0.2.14:
   dependencies:
     fdir "^6.4.4"
     picomatch "^4.0.2"
+
+tinypool@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-2.1.0.tgz#303a671d6ef68d03c9512cdc9a47c86b8a85f20c"
+  integrity sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==
 
 tinypool@^1.1.1:
   version "1.1.1"
@@ -1340,6 +1818,15 @@ wrap-ansi@^8.1.0:
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
 
+wrap-ansi@^9.0.0:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz#956832dea9494306e6d209eb871643bb873d7c98"
+  integrity sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==
+  dependencies:
+    ansi-styles "^6.2.1"
+    string-width "^7.0.0"
+    strip-ansi "^7.1.0"
+
 xml-escape@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/xml-escape/-/xml-escape-1.1.0.tgz#3904c143fa8eb3a0030ec646d2902a2f1b706c44"
@@ -1349,3 +1836,8 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yaml@^2.8.2:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==


### PR DESCRIPTION
This PR applies comprehensive code formatting and linting standards across the codebase using oxfmt and oxlint tools.

## Summary
Standardized code formatting and style consistency throughout the project by applying automated formatting rules and configuring linting tools.

## Key Changes

**Formatting Updates:**
- Converted all double quotes to single quotes in imports and strings
- Reformatted long lines to respect the 100-character print width limit
- Fixed spacing around conditional statements (e.g., `if(` → `if (`)
- Standardized trailing commas in multi-line constructs
- Adjusted indentation in class definitions and object literals
- Reformatted function signatures and type annotations for consistency

**Configuration & Tooling:**
- Added `.oxfmtrc.json` configuration for oxfmt with settings for trailing commas, tab width (2), single quotes, and 100-character print width
- Added `.oxlintrc.json` configuration for oxlint with ESLint, TypeScript, Unicorn, and import plugins enabled
- Added `.husky/pre-commit` hook to run `yarn lint-staged` for pre-commit linting
- Updated `package.json` with new scripts:
  - `lint`: Run oxfmt and oxlint checks
  - `lint:fix`: Auto-fix formatting and linting issues
  - `prepare`: Initialize husky hooks
- Updated `tsconfig.json` to use `Node16` module resolution instead of `Node`
- Updated `.npmignore` to exclude husky and linting configuration files
- Added GitHub Actions workflow (`.github/workflows/lint.yml`) for automated linting on push and pull requests

**Files Modified:**
- All source files in `src/` directory
- All test files in `test/` directory
- Configuration files and test setup files

## Notable Details
- No functional code changes; this is purely a formatting and linting standardization
- The changes ensure consistent code style across the entire project
- Pre-commit hooks will enforce linting standards going forward
- CI/CD pipeline now includes automated linting checks

https://claude.ai/code/session_01HSt7yZdYTKp7VfT7g66UyK